### PR TITLE
remove error message workaround

### DIFF
--- a/force-app/main/default/lwc/inlineMessage/inlineMessage.js
+++ b/force-app/main/default/lwc/inlineMessage/inlineMessage.js
@@ -41,19 +41,7 @@ export default class InlineMessage extends LightningElement {
         // Filter out null items and error objects that don't have a message attribute.
         // As a convenience, a component can pass all its @wired properties .error references even if they are null,
         // moving the burden of filtering from each individual component to this central location.
-
-        // TODO: Uncomment line below and remove workaround when W-5644412 is fixed
-        // this._errors = value.filter(error => error && error.message);
-        // W-5644412 workaround
-        this._errors = value
-            .filter(
-                error =>
-                    error &&
-                    error.details &&
-                    error.details.body &&
-                    error.details.body.message,
-            )
-            .map(error => ({ message: error.details.body.message }));
+        this._errors = value.filter(error => error && error.message);
     }
 
     handleCheckboxChange(event) {


### PR DESCRIPTION
The bug referenced in the workaround has been fixed. The non-workaround code is much simpler and makes fewer assumptions about the shape of the error object.