### PR TITLE
Jest test updates for new apex wire adapter testing util

### DIFF
--- a/force-app/main/default/lwc/productFilter/__tests__/productFilter.test.js
+++ b/force-app/main/default/lwc/productFilter/__tests__/productFilter.test.js
@@ -4,7 +4,7 @@ import { fireEvent } from 'c/pubsub';
 import {
     registerLdsTestWireAdapter,
     registerTestWireAdapter
-} from '@salesforce/wire-service-jest-util';
+} from '@salesforce/lwc-jest';
 import { CurrentPageReference } from 'lightning/navigation';
 import { getPicklistValues } from 'lightning/uiObjectInfoApi';
 

--- a/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
+++ b/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
@@ -3,7 +3,7 @@ import ProductTileList from 'c/productTileList';
 import { fireEvent } from 'c/pubsub';
 import {
     registerTestWireAdapter,
-    registerLdsTestWireAdapter
+    registerApexTestWireAdapter
 } from '@salesforce/wire-service-jest-util';
 import getProducts from '@salesforce/apex/ProductController.getProducts';
 import { CurrentPageReference } from 'lightning/navigation';
@@ -23,8 +23,8 @@ const mockGetProducts = require('./data/getProducts.json');
 // when there is no data to display
 const mockGetProductsNoRecords = require('./data/getProductsNoRecords.json');
 
-// Register as an LDS wire adapter. Some tests verify that provisioned values trigger desired behavior.
-const getProductsAdapter = registerLdsTestWireAdapter(getProducts);
+// Register the Apex wire adapter. Some tests verify that provisioned values trigger desired behavior.
+const getProductsAdapter = registerApexTestWireAdapter(getProducts);
 
 // Register as a standard wire adapter because the component under test requires this adapter.
 // We don't exercise this wire adapter in the tests.
@@ -214,6 +214,7 @@ describe('c-product-tile-list', () => {
                 const inlineMessage = element.shadowRoot.querySelector(
                     'c-inline-message'
                 );
+                // TODO - validate more detail
                 expect(inlineMessage).not.toBeNull();
             });
         });

--- a/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
+++ b/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
@@ -4,7 +4,7 @@ import { fireEvent } from 'c/pubsub';
 import {
     registerTestWireAdapter,
     registerApexTestWireAdapter
-} from '@salesforce/wire-service-jest-util';
+} from '@salesforce/lwc-jest';
 import getProducts from '@salesforce/apex/ProductController.getProducts';
 import { CurrentPageReference } from 'lightning/navigation';
 
@@ -204,19 +204,34 @@ describe('c-product-tile-list', () => {
     });
 
     describe('getProducts @wire error', () => {
-        it('shows error message element', () => {
+        it('shows error message element with error details populated', () => {
+            // This is the default error message that gets emitted from apex
+            // adapters. See @salesforce/wire-service-jest-util for the source.
+            const defaultError = 'An internal server error has occurred';
             const element = createElement('c-product-tile-list', {
                 is: ProductTileList
             });
             document.body.appendChild(element);
             getProductsAdapter.error();
-            return Promise.resolve().then(() => {
-                const inlineMessage = element.shadowRoot.querySelector(
-                    'c-inline-message'
-                );
-                // TODO - validate more detail
-                expect(inlineMessage).not.toBeNull();
-            });
+            return Promise.resolve()
+                .then(() => {
+                    const inlineMessage = element.shadowRoot.querySelector(
+                        'c-inline-message'
+                    );
+                    // check the "Show Details" checkbox to render additional error messages
+                    const lightningInput = inlineMessage.shadowRoot.querySelector(
+                        'lightning-input'
+                    );
+                    lightningInput.checked = true;
+                    lightningInput.dispatchEvent(new CustomEvent('change'));
+                })
+                .then(() => {
+                    const inlineMessage = element.shadowRoot.querySelector(
+                        'c-inline-message'
+                    );
+                    const text = inlineMessage.shadowRoot.textContent;
+                    expect(text).toContain(defaultError);
+                });
         });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -761,28 +761,28 @@
             "dev": true
         },
         "@lwc/babel-plugin-component": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-0.33.28-5.tgz",
-            "integrity": "sha512-peE42j4W2jpvFJjjbUZEQYtdQow2vGLLkkgDxIWgh+iW0EgshmDhqXghpltywWKi4ud3dNAPHzlvAkWGT/VVQg==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-0.34.4.tgz",
+            "integrity": "sha512-fAMpAl8j+dv0GT0Yj8mNhQ3SUUVFmW31a/RK/ksQBgGY5OfvYDcEJL2pwCoowbCVOrv0/OLWTLFS4HdbHYeITg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "7.0.0",
                 "@babel/plugin-proposal-class-properties": "7.1.0",
-                "@lwc/errors": "0.33.28-5"
+                "@lwc/errors": "0.34.4"
             }
         },
         "@lwc/compiler": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-0.33.28-5.tgz",
-            "integrity": "sha512-1sFIUsTm3zKUk62oVAsI5DsjUaM4Rj5mQdHXBFgY22yzHgFZt428MonCWCUiLqlb0zL7PRI3s/Psm3WXMoimaw==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-0.34.4.tgz",
+            "integrity": "sha512-j/U5fw/Yygk4b2SC2/zPhYBYDGanoi2wGydxnTmEY3QYC25CC0c9eklf+ZqP8C8zYaK4cF8ZngPPTm6V+DNSPA==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.1.0",
                 "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-                "@lwc/babel-plugin-component": "0.33.28-5",
-                "@lwc/errors": "0.33.28-5",
-                "@lwc/style-compiler": "0.33.28-5",
-                "@lwc/template-compiler": "0.33.28-5",
+                "@lwc/babel-plugin-component": "0.34.4",
+                "@lwc/errors": "0.34.4",
+                "@lwc/style-compiler": "0.34.4",
+                "@lwc/template-compiler": "0.34.4",
                 "@types/chokidar": "^1.7.5",
                 "babel-preset-compat": "0.21.0",
                 "babel-preset-minify": "0.5.0-alpha.5a128fd5",
@@ -791,18 +791,18 @@
             }
         },
         "@lwc/engine": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-0.33.28-5.tgz",
-            "integrity": "sha512-3xJvECWOmYGHWGmsUcDNVhLVrhHZc6gBlxxjLoN+XDCV5MBMaCAEM52Y2ryNQTc/Q+R8vqdFwtlzJ0NStm/aDQ==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-0.34.4.tgz",
+            "integrity": "sha512-MoaQdxw8zI9Zcxi0bqfg9YEHkfAiYc8oU8cEi10THjmlFE+qtUFpGz2H920YXy++2NQUJ4Orw99sI3n+zX5I7A==",
             "dev": true,
             "requires": {
                 "observable-membrane": "0.25.0"
             }
         },
         "@lwc/errors": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-0.33.28-5.tgz",
-            "integrity": "sha512-BV8Ld4GVI/SvqQFi+G2FcK0HDPzg5qwlCw+j24k2qumuZWK85cFx/8xH0dKFiLWYZrAESf99Jjni/gdNRkC9OQ==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-0.34.4.tgz",
+            "integrity": "sha512-AGICwjXEy1y3RsfXf3KDUEIM6a9h8OBxhywN2O86fcA+pJb+ZVyjT0EpSFg55fBTHIvUXeV2H2R8Z91pnCM6lA==",
             "dev": true
         },
         "@lwc/eslint-plugin-lwc": {
@@ -812,39 +812,39 @@
             "dev": true
         },
         "@lwc/jest-preset": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-0.33.28-5.tgz",
-            "integrity": "sha512-G47NLi6fBcl+oD0IFoFYUxViFh5uavZXNbSMVttkQcvfC2BfglneXg6Fqy+64ydsBNVo/pW1fuHbPgXLzLWzmA==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-0.34.4.tgz",
+            "integrity": "sha512-9SQsKTuSklyi9cJ1FsNyFnnDYButM5JIXmlDu8Rk5Sj7YxSeiMrpakdefT2rXK8hfK3SowlYTreDl0shsBS+qg==",
             "dev": true,
             "requires": {
-                "@lwc/jest-resolver": "0.33.28-5",
-                "@lwc/jest-serializer": "0.33.28-5",
-                "@lwc/jest-transformer": "0.33.28-5",
-                "@lwc/test-utils": "0.33.28-5"
+                "@lwc/jest-resolver": "0.34.4",
+                "@lwc/jest-serializer": "0.34.4",
+                "@lwc/jest-transformer": "0.34.4",
+                "@lwc/test-utils": "0.34.4"
             }
         },
         "@lwc/jest-resolver": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-0.33.28-5.tgz",
-            "integrity": "sha512-zoR/EooxAX9j7TGuR5UcffcGefANasDwiGdg6KF1mDBS5i4x0tH/+rPuN5E6AISf1Ci8Eskr33TS5DqU2UqDRw==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-0.34.4.tgz",
+            "integrity": "sha512-kmXfoOhQm3egDjpG025exmqXzzqsX//IlTCdaWb4luaLSMh3L7AMG2rSsHzZNKRSdcRZndczr9II8b8gFjV/VQ==",
             "dev": true
         },
         "@lwc/jest-serializer": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-0.33.28-5.tgz",
-            "integrity": "sha512-oHUHfpEicCqGkvARlQPcJ3BmN3v6MdKeoVRs9glGVq3V6T1LQBmiC2yNQXmJ0xM5W79EVCAWzaXmVisUQeKpAg==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-0.34.4.tgz",
+            "integrity": "sha512-iY1G81GNLtlxBF4As4Hu59s0fzHPTZihdx125ujYateWjXiFS8ZWiWQkkuBwSjnqk8JF65WJPopp/uPIdvIXCg==",
             "dev": true
         },
         "@lwc/jest-transformer": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-0.33.28-5.tgz",
-            "integrity": "sha512-rr8eSXscWebVAk6yMhHU7d3OSdqFuv1lewfGfJPQr5AgJ6D3KkVg3Ls17ElAbAsV9WrZxcS2KJnWC04SPR4BBg==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-0.34.4.tgz",
+            "integrity": "sha512-j3rgAc5xmcZAyrFC9Dm7ThIzYcR33HGu15wS/Fj9geH4n8EZueiY7/CwsDll6nPA+xDME4Par+AkLiO4BbEXfw==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.1.0",
                 "@babel/plugin-transform-modules-commonjs": "7.1.0",
                 "@babel/template": "~7.1.2",
-                "@lwc/errors": "0.33.28-5",
+                "@lwc/errors": "0.34.4",
                 "deasync": "0.1.12"
             },
             "dependencies": {
@@ -858,32 +858,22 @@
                         "@babel/parser": "^7.1.2",
                         "@babel/types": "^7.1.2"
                     }
-                },
-                "deasync": {
-                    "version": "0.1.12",
-                    "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.12.tgz",
-                    "integrity": "sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==",
-                    "dev": true,
-                    "requires": {
-                        "bindings": "~1.2.1",
-                        "nan": "^2.0.7"
-                    }
                 }
             }
         },
         "@lwc/module-resolver": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-0.33.28-5.tgz",
-            "integrity": "sha512-tDPfxJmfpfr0Wb4PeeLJ8Ssw6TtrPg2ckqNrUrFyK3EhyGMWMUVyRp8Pkw0T51IrQM+cyWCnAMjQSny+MHDJ5A==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-0.34.4.tgz",
+            "integrity": "sha512-3RMKu937ZYR+ZpvBxwO7O6qYWiqC3Y7G1UZhik19CJQHdcpU5fxQbN8vbRlRXw2U0y2UiUl6ax2Z8zv2PifR1w==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2"
             }
         },
         "@lwc/style-compiler": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-0.33.28-5.tgz",
-            "integrity": "sha512-LU1UNWVp587kSzNwgj9ALktXaEoRud6+31kumwmF4rnX2x9FK93MzjlRWgVJLNtrhaGFBDFxPH42/ap3x7PEww==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-0.34.4.tgz",
+            "integrity": "sha512-sywbPGmqSKLKaZxYj0u8eKLKvaCZhKXMo3/BDuEF5Zo5EuqK1yMTSKhKjZnpAXcoiDQmhRZpwMI/FAW5J1wKsA==",
             "dev": true,
             "requires": {
                 "cssnano": "~3.10.0",
@@ -893,9 +883,9 @@
             }
         },
         "@lwc/template-compiler": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-0.33.28-5.tgz",
-            "integrity": "sha512-yJifm2H5dpwVGvgXi7u5hqu4KVsSzNwyDWuFJKc6YAYRitXMnZEZSbVGRw7jL3SM9a1vNUv+EnuPV2k0VQR6BQ==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-0.34.4.tgz",
+            "integrity": "sha512-QeYlE4U43Qbf0M9xwepuNSH8ulpofo9tR71QdB1wE9qupGL9JJOsd3Osz6B97HTyYSeYI4wzdjaY8ohB/RzJuA==",
             "dev": true,
             "requires": {
                 "@babel/generator": "~7.1.5",
@@ -903,8 +893,8 @@
                 "@babel/template": "~7.1.2",
                 "@babel/traverse": "~7.1.5",
                 "@babel/types": "~7.1.5",
-                "@lwc/errors": "0.33.28-5",
-                "@lwc/style-compiler": "0.33.28-5",
+                "@lwc/errors": "0.34.4",
+                "@lwc/style-compiler": "0.34.4",
                 "camelcase": "~5.0.0",
                 "he": "^1.1.1",
                 "parse5-with-errors": "^4.0.1"
@@ -971,15 +961,15 @@
             }
         },
         "@lwc/test-utils": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/test-utils/-/test-utils-0.33.28-5.tgz",
-            "integrity": "sha512-swPEt6yXAhHLWm1VDEfr4c0FmDsxb1xiE7viBOXqd4f6v/vLN9UxJFSk9607LnzHj5pNssM7nmk+QVtqBq4JaQ==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/test-utils/-/test-utils-0.34.4.tgz",
+            "integrity": "sha512-G6Ex66ZWYpGBvp8GumQxx3ttIEbXdRkUUnRFrBpSvAjiI6UHJfZ1eOC894DRTm1KBP52fiq2zyYDLa3POZR4sg==",
             "dev": true
         },
         "@lwc/wire-service": {
-            "version": "0.33.28-5",
-            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-0.33.28-5.tgz",
-            "integrity": "sha512-pirs0MNbEDBglNGgVCdd7tmoN5ywGMxs6F6TTa1fgNZgr1EH9QM3gJPC4MJRCpV7bLQB8JQmJ1j6jbtDwuQFWA==",
+            "version": "0.34.4",
+            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-0.34.4.tgz",
+            "integrity": "sha512-1JqYgKswHX+pLhJe7+60udTk/xZvvGPuDN34Z37ES4oIU9kps7eVCGXHXa9clhW/PA8FC6y2hO6Yt2NqbAfICg==",
             "dev": true
         },
         "@salesforce/eslint-config-lwc": {
@@ -995,34 +985,30 @@
             }
         },
         "@salesforce/lwc-jest": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/@salesforce/lwc-jest/-/lwc-jest-0.4.7.tgz",
-            "integrity": "sha512-HNJn06kfogCHrPY8V4BAAufVqBu+ix+XGougym+LjFZQXBbmPiKVLzEiEHS01pAnMuuZD1HK5g5LZoxeMOrCig==",
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/@salesforce/lwc-jest/-/lwc-jest-0.4.10.tgz",
+            "integrity": "sha512-ahcRwWracKrByoBrV1uG2x3xjDiaPVC5Xc2NhXCptxskPMGsjj6AbTbnKCEO9Ldx6kFE0aWyA1e6r9xMmlQdbg==",
             "dev": true,
             "requires": {
-                "@lwc/compiler": "0.33.28-5",
-                "@lwc/engine": "0.33.28-5",
-                "@lwc/jest-preset": "0.33.28-5",
-                "@lwc/jest-resolver": "0.33.28-5",
-                "@lwc/jest-serializer": "0.33.28-5",
-                "@lwc/jest-transformer": "0.33.28-5",
-                "@lwc/module-resolver": "0.33.28-5",
-                "@lwc/wire-service": "0.33.28-5",
-                "@salesforce/wire-service-jest-util": "^2.2.4",
-                "babel-core": "^6.24.1",
-                "babel-preset-env": "^1.6.1",
-                "babel-preset-jest": "^22.1.0",
+                "@lwc/compiler": "0.34.4",
+                "@lwc/engine": "0.34.4",
+                "@lwc/jest-preset": "0.34.4",
+                "@lwc/jest-resolver": "0.34.4",
+                "@lwc/jest-serializer": "0.34.4",
+                "@lwc/jest-transformer": "0.34.4",
+                "@lwc/module-resolver": "0.34.4",
+                "@lwc/wire-service": "0.34.4",
+                "@salesforce/wire-service-jest-util": "^2.2.5",
                 "chalk": "^2.3.0",
-                "deasync": "^0.1.10",
                 "glob": "^7.1.2",
                 "jest": "~23.6.0",
                 "yargs": "^10.0.3"
             }
         },
         "@salesforce/wire-service-jest-util": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@salesforce/wire-service-jest-util/-/wire-service-jest-util-2.2.4.tgz",
-            "integrity": "sha512-fKm3PqxFJqAEKEJ6LVzKRWd2dFfDkvzH/ssQMdfyZQelyXYFPT49UQ4a9MD0GrADA3Mt8vDWunhlv9guBTc04A==",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@salesforce/wire-service-jest-util/-/wire-service-jest-util-2.2.5.tgz",
+            "integrity": "sha512-eOU8F4RQdPUXShocWHsEx+eHuPorzvCHUlWM5VDne4jfL6MY1C351UrrSGXqjnZFaFBjJrpS2P1eGq0UjCnJLw==",
             "dev": true
         },
         "@samverschueren/stream-to-observable": {
@@ -1057,9 +1043,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.2.tgz",
-            "integrity": "sha512-JWB3xaVfsfnFY8Ofc9rTB/op0fqqTSqy4vBcVk1LuRJvta7KTX+D//fCkiTMeLGhdr2EbFZzQjC97gvmPilk9Q==",
+            "version": "6.14.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.3.tgz",
+            "integrity": "sha512-V2VrQBCKo4U0rni6tW4AASRDqIO5ZTLDN/Xzrm4mNBr9SGQYZ+7zZJn+hMs89Q8ZCIHzp4aWQPyCpK+rux1YGA==",
             "dev": true
         },
         "@types/semver": {
@@ -1109,9 +1095,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-                    "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+                    "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
                     "dev": true
                 }
             }
@@ -1827,96 +1813,17 @@
                 }
             }
         },
-        "babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-            "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-            "dev": true,
-            "requires": {
-                "babel-helper-explode-assignable-expression": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-call-delegate": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-            "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-define-map": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-            "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
         "babel-helper-evaluate-path": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
             "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==",
             "dev": true
         },
-        "babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-            "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
         "babel-helper-flip-expressions": {
             "version": "0.5.0-alpha.e9f96ffe",
             "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.5.0-alpha.e9f96ffe.tgz",
             "integrity": "sha1-+jkpMUFyoTpWy8grOVxOLGwJgCU=",
             "dev": true
-        },
-        "babel-helper-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-            "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-            "dev": true,
-            "requires": {
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-get-function-arity": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-            "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-hoist-variables": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-            "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
         },
         "babel-helper-is-nodes-equiv": {
             "version": "0.0.1",
@@ -1936,59 +1843,11 @@
             "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
             "dev": true
         },
-        "babel-helper-optimise-call-expression": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-            "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-helper-regex": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-            "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
         "babel-helper-remove-or-void": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
             "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
             "dev": true
-        },
-        "babel-helper-replace-supers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-            "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-            "dev": true,
-            "requires": {
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
         },
         "babel-helper-to-multiple-sequence-expressions": {
             "version": "0.5.0",
@@ -2014,39 +1873,12 @@
             "requires": {
                 "babel-plugin-istanbul": "^4.1.6",
                 "babel-preset-jest": "^23.2.0"
-            },
-            "dependencies": {
-                "babel-plugin-jest-hoist": {
-                    "version": "23.2.0",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
-                    "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
-                    "dev": true
-                },
-                "babel-preset-jest": {
-                    "version": "23.2.0",
-                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
-                    "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
-                    "dev": true,
-                    "requires": {
-                        "babel-plugin-jest-hoist": "^23.2.0",
-                        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
-                    }
-                }
             }
         },
         "babel-messages": {
             "version": "6.23.0",
             "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-check-es2015-constants": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-            "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "dev": true,
             "requires": {
                 "babel-runtime": "^6.22.0"
@@ -2065,9 +1897,9 @@
             }
         },
         "babel-plugin-jest-hoist": {
-            "version": "22.4.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
-            "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+            "version": "23.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+            "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
             "dev": true
         },
         "babel-plugin-minify-builtins": {
@@ -2170,319 +2002,11 @@
                 "babel-helper-is-void-0": "^0.5.0-alpha.e9f96ffe"
             }
         },
-        "babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-            "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-            "dev": true
-        },
-        "babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-            "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-            "dev": true
-        },
         "babel-plugin-syntax-object-rest-spread": {
             "version": "6.13.0",
             "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
             "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
             "dev": true
-        },
-        "babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-            "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-            "dev": true
-        },
-        "babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-            "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-            "dev": true,
-            "requires": {
-                "babel-helper-remap-async-to-generator": "^6.24.1",
-                "babel-plugin-syntax-async-functions": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-            "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-            "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-            "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "babel-plugin-transform-es2015-classes": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-            "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-            "dev": true,
-            "requires": {
-                "babel-helper-define-map": "^6.24.1",
-                "babel-helper-function-name": "^6.24.1",
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-            "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-            "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-            "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-            "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-            "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-            "dev": true,
-            "requires": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-            "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-            "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-strict-mode": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-types": "^6.26.0"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-            "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-            "dev": true,
-            "requires": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-            "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-            "dev": true,
-            "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-            "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-            "dev": true,
-            "requires": {
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-            "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-            "dev": true,
-            "requires": {
-                "babel-helper-call-delegate": "^6.24.1",
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-            "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-spread": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-            "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-            "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-            "version": "6.22.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-            "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-            "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-            "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-            "dev": true,
-            "requires": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "regexpu-core": "^2.0.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
-                },
-                "regexpu-core": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-                    "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-                    "dev": true,
-                    "requires": {
-                        "regenerate": "^1.2.1",
-                        "regjsgen": "^0.2.0",
-                        "regjsparser": "^0.1.4"
-                    }
-                },
-                "regjsgen": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                    "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-                    "dev": true
-                },
-                "regjsparser": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                    "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-                    "dev": true,
-                    "requires": {
-                        "jsesc": "~0.5.0"
-                    }
-                }
-            }
-        },
-        "babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-            "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-            "dev": true,
-            "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
         },
         "babel-plugin-transform-inline-consecutive-adds": {
             "version": "0.5.0-alpha.e9f96ffe",
@@ -2539,28 +2063,6 @@
                 }
             }
         },
-        "babel-plugin-transform-regenerator": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-            "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-            "dev": true,
-            "requires": {
-                "regenerator-transform": "^0.10.0"
-            },
-            "dependencies": {
-                "regenerator-transform": {
-                    "version": "0.10.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-                    "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-                    "dev": true,
-                    "requires": {
-                        "babel-runtime": "^6.18.0",
-                        "babel-types": "^6.19.0",
-                        "private": "^0.1.6"
-                    }
-                }
-            }
-        },
         "babel-plugin-transform-regexp-constructors": {
             "version": "0.5.0-alpha.e9f96ffe",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.5.0-alpha.e9f96ffe.tgz",
@@ -2593,16 +2095,6 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
             "integrity": "sha1-9UmabcPtaGvaUzY4ZrZ92ndMW+0=",
             "dev": true
-        },
-        "babel-plugin-transform-strict-mode": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-            "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
         },
         "babel-plugin-transform-undefined-to-void": {
             "version": "6.10.0-alpha.f95869d4",
@@ -2648,63 +2140,13 @@
                 "babel-plugin-transform-proxy-compat": "0.21.0"
             }
         },
-        "babel-preset-env": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-            "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-            "dev": true,
-            "requires": {
-                "babel-plugin-check-es2015-constants": "^6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-                "babel-plugin-transform-async-to-generator": "^6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-                "babel-plugin-transform-es2015-classes": "^6.23.0",
-                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-                "babel-plugin-transform-es2015-for-of": "^6.23.0",
-                "babel-plugin-transform-es2015-function-name": "^6.22.0",
-                "babel-plugin-transform-es2015-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-                "babel-plugin-transform-es2015-object-super": "^6.22.0",
-                "babel-plugin-transform-es2015-parameters": "^6.23.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-                "babel-plugin-transform-es2015-spread": "^6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-                "babel-plugin-transform-regenerator": "^6.22.0",
-                "browserslist": "^3.2.6",
-                "invariant": "^2.2.2",
-                "semver": "^5.3.0"
-            },
-            "dependencies": {
-                "browserslist": {
-                    "version": "3.2.8",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-                    "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-lite": "^1.0.30000844",
-                        "electron-to-chromium": "^1.3.47"
-                    }
-                }
-            }
-        },
         "babel-preset-jest": {
-            "version": "22.4.4",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
-            "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+            "version": "23.2.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+            "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^22.4.4",
+                "babel-plugin-jest-hoist": "^23.2.0",
                 "babel-plugin-syntax-object-rest-spread": "^6.13.0"
             }
         },
@@ -3080,15 +2522,9 @@
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000932",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000932.tgz",
-            "integrity": "sha512-nc4jIhwpajQCvADmBo3F1fj8ySvE2+dw0lXAmYmtYJi1l7CvfdZVTkrwD60SrQHDC1mddgYtLyAcwrtYVtiMSQ==",
-            "dev": true
-        },
-        "caniuse-lite": {
-            "version": "1.0.30000932",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000932.tgz",
-            "integrity": "sha512-4bghJFItvzz8m0T3lLZbacmEY9X1Z2AtIzTr7s7byqZIOumASfr4ynDx7rtm0J85nDmx8vsgR6vnaSoeU8Oh0A==",
+            "version": "1.0.30000938",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000938.tgz",
+            "integrity": "sha512-1lbcoAGPQFUYOdY7sxpsl8ZDBfn5cyn80XuYnZwk7N4Qp7Behw7uxZCH5jjH2qWTV2WM6hgjvDVpP/uV3M/l9g==",
             "dev": true
         },
         "capture-exit": {
@@ -3453,9 +2889,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-            "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+            "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
             "dev": true
         },
         "core-util-is": {
@@ -3638,9 +3074,9 @@
             }
         },
         "cssom": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-            "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
             "dev": true
         },
         "cssstyle": {
@@ -3698,13 +3134,13 @@
             "dev": true
         },
         "deasync": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.14.tgz",
-            "integrity": "sha512-wN8sIuEqIwyQh72AG7oY6YQODCxIp1eXzEZlZznBuwDF8Q03Tdy9QNp1BNZXeadXoklNrw+Ip1fch+KXo/+ASw==",
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.12.tgz",
+            "integrity": "sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==",
             "dev": true,
             "requires": {
                 "bindings": "~1.2.1",
-                "node-addon-api": "^1.6.0"
+                "nan": "^2.0.7"
             }
         },
         "debug": {
@@ -3950,9 +3386,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.108",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.108.tgz",
-            "integrity": "sha512-/QI4hMpAh48a1Sea6PALGv+kuVne9A2EWGd8HrWHMdYhIzGtbhVVHh6heL5fAzGaDnZuPyrlWJRl8WPm4RyiQQ==",
+            "version": "1.3.113",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+            "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
             "dev": true
         },
         "elegant-spinner": {
@@ -4632,28 +4068,24 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.1",
-                    "resolved": false,
-                    "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "resolved": false,
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "bundled": true,
                     "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
-                    "resolved": false,
-                    "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
-                    "resolved": false,
-                    "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4663,14 +4095,12 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "bundled": true,
                     "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": false,
-                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
@@ -4679,40 +4109,34 @@
                 },
                 "chownr": {
                     "version": "1.1.1",
-                    "resolved": false,
-                    "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "bundled": true,
                     "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "bundled": true,
                     "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "resolved": false,
-                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                    "bundled": true,
                     "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "2.6.9",
-                    "resolved": false,
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4721,29 +4145,25 @@
                 },
                 "deep-extend": {
                     "version": "0.6.0",
-                    "resolved": false,
-                    "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
-                    "resolved": false,
-                    "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
-                    "resolved": false,
-                    "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4752,15 +4172,13 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "resolved": false,
-                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4776,8 +4194,7 @@
                 },
                 "glob": {
                     "version": "7.1.3",
-                    "resolved": false,
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4791,15 +4208,13 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
-                    "resolved": false,
-                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4808,8 +4223,7 @@
                 },
                 "ignore-walk": {
                     "version": "3.0.1",
-                    "resolved": false,
-                    "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4818,8 +4232,7 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": false,
-                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4829,21 +4242,18 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "resolved": false,
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "bundled": true,
                     "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
-                    "resolved": false,
-                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -4851,15 +4261,13 @@
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": false,
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
@@ -4867,14 +4275,12 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": false,
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "bundled": true,
                     "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
-                    "resolved": false,
-                    "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
@@ -4883,8 +4289,7 @@
                 },
                 "minizlib": {
                     "version": "1.2.1",
-                    "resolved": false,
-                    "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4893,8 +4298,7 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": false,
-                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -4902,15 +4306,13 @@
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.2.4",
-                    "resolved": false,
-                    "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4921,8 +4323,7 @@
                 },
                 "node-pre-gyp": {
                     "version": "0.10.3",
-                    "resolved": false,
-                    "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4940,8 +4341,7 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4951,15 +4351,13 @@
                 },
                 "npm-bundled": {
                     "version": "1.0.5",
-                    "resolved": false,
-                    "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.2.0",
-                    "resolved": false,
-                    "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4969,8 +4367,7 @@
                 },
                 "npmlog": {
                     "version": "4.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -4982,21 +4379,18 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "bundled": true,
                     "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "resolved": false,
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": false,
-                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "wrappy": "1"
@@ -5004,22 +4398,19 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
-                    "resolved": false,
-                    "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5029,22 +4420,19 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
-                    "resolved": false,
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
-                    "resolved": false,
-                    "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5056,8 +4444,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": false,
-                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         }
@@ -5065,8 +4452,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": false,
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5081,8 +4467,7 @@
                 },
                 "rimraf": {
                     "version": "2.6.3",
-                    "resolved": false,
-                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5091,49 +4476,42 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "bundled": true,
                     "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
-                    "resolved": false,
-                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
-                    "resolved": false,
-                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.6.0",
-                    "resolved": false,
-                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": false,
-                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -5143,8 +4521,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": false,
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5153,8 +4530,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "bundled": true,
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -5162,15 +4538,13 @@
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "resolved": false,
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
-                    "resolved": false,
-                    "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5185,15 +4559,13 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
-                    "resolved": false,
-                    "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                    "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
@@ -5202,14 +4574,12 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
-                    "resolved": false,
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "bundled": true,
                     "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "resolved": false,
-                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+                    "bundled": true,
                     "dev": true
                 }
             }
@@ -6168,6 +5538,12 @@
             "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
             "dev": true
         },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6488,7 +5864,7 @@
         },
         "jest-get-type": {
             "version": "22.4.3",
-            "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
             "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
             "dev": true
         },
@@ -7586,12 +6962,12 @@
             }
         },
         "magic-string": {
-            "version": "0.25.1",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-            "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+            "version": "0.25.2",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+            "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
             "dev": true,
             "requires": {
-                "sourcemap-codec": "^1.4.1"
+                "sourcemap-codec": "^1.4.4"
             }
         },
         "makeerror": {
@@ -7691,18 +7067,18 @@
             }
         },
         "mime-db": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+            "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "version": "2.1.22",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+            "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "~1.38.0"
             }
         },
         "mimic-fn": {
@@ -7831,12 +7207,6 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
-        "node-addon-api": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.2.tgz",
-            "integrity": "sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==",
-            "dev": true
-        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7844,12 +7214,13 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
-            "integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
+                "is-wsl": "^1.1.0",
                 "semver": "^5.5.0",
                 "shellwords": "^0.1.1",
                 "which": "^1.3.0"
@@ -7936,9 +7307,9 @@
             "dev": true
         },
         "nwsapi": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-            "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.0.tgz",
+            "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==",
             "dev": true
         },
         "oauth-sign": {
@@ -7976,9 +7347,9 @@
             }
         },
         "object-keys": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
             "dev": true
         },
         "object-visit": {
@@ -10553,9 +9924,9 @@
             }
         },
         "realpath-native": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-            "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "dev": true,
             "requires": {
                 "util.promisify": "^1.0.0"
@@ -10810,23 +10181,23 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "^4.17.11"
             }
         },
         "request-promise-native": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@salesforce/eslint-config-lwc": "^0.3.0",
-        "@salesforce/lwc-jest": "^0.4.7",
+        "@salesforce/lwc-jest": "^0.4.10",
         "eslint": "^5.13.0",
         "husky": "^1.3.1",
         "lint-staged": "^8.1.3",


### PR DESCRIPTION
- Upgrade lwc-jest to 0.4.10
- Import wire service testing utilities directly from `@saleforce/lwc-jest`, which re-exports them from `@salesforce/wire-service-jest-util`
- For testing Apex methods connected to a `@wire`, use new testing API `registerApexTestWireAdapter`.