### PR TITLE
upgrade handlebars to resolve npm vulnerability warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -716,7 +716,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -1153,7 +1153,7 @@
         },
         "ansi-escapes": {
             "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
             "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
             "dev": true
         },
@@ -2499,7 +2499,7 @@
         },
         "callsites": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
             "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
             "dev": true
         },
@@ -2694,7 +2694,7 @@
                 },
                 "slice-ansi": {
                     "version": "0.0.4",
-                    "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
                     "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
                     "dev": true
                 },
@@ -3315,7 +3315,7 @@
         },
         "doctrine": {
             "version": "1.5.0",
-            "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
             "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
             "dev": true,
             "requires": {
@@ -4687,7 +4687,7 @@
         },
         "globby": {
             "version": "6.1.0",
-            "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
@@ -4720,9 +4720,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-            "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+            "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
             "dev": true,
             "requires": {
                 "async": "^2.5.0",
@@ -5249,7 +5249,7 @@
         },
         "is-builtin-module": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
@@ -5391,7 +5391,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -6775,7 +6775,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -6827,7 +6827,7 @@
         },
         "load-json-file": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
@@ -7098,7 +7098,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
@@ -7125,7 +7125,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -7481,7 +7481,7 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -7607,7 +7607,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -7646,7 +7646,7 @@
         },
         "pify": {
             "version": "2.3.0",
-            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
             "dev": true
         },
@@ -10336,7 +10336,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -10996,7 +10996,7 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
@@ -11150,7 +11150,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -11165,7 +11165,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
@@ -11331,7 +11331,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },


### PR DESCRIPTION
During an `npm install`, npm emits the following warning:

`found 65 vulnerabilities (63 low, 2 high)`

The two high vulnerabilities are from the handlebars transitive dependency. Upgrading that version of handlebars resolves the warning.