### PR TITLE
VS Code extensions properly detect hasSampleData as boolean

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,7 @@
 {
     "orgName": "Ebikes",
     "edition": "Developer",
-    "hasSampleData": "false",
+    "hasSampleData": false,
     "settings": {
         "orgPreferenceSettings": {
             "s1DesktopEnabled": true,

--- a/force-app/main/default/lwc/productTileList/productTileList.js
+++ b/force-app/main/default/lwc/productTileList/productTileList.js
@@ -23,9 +23,6 @@ export default class ProductTileList extends LightningElement {
      */
     @api tilesAreDraggable = false;
 
-    /** All available Product__c[]. */
-    @track products = [];
-
     /** Current page in the product list. */
     @track pageNumber = 1;
 


### PR DESCRIPTION
Originally VS Code would complain that hasSampleData was a String. It's been [fixed](https://org62.lightning.force.com/lightning/r/0D50M00004ILlc7SAD/view).