### PR TITLE
Adding Dev Org installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,27 +138,21 @@ sfdx force:user:permset:assign -n ebikes
 sfdx force:data:tree:import --plan ./data/sample-data-plan.json
 ```
 
-11. Deploy Community metadata
-
-```
-sfdx force:mdapi:deploy -u ebikes --deploydir mdapiDeploy/unpackaged -w 1
-```
-
-12. Open the scratch org:
+11. Open the scratch org:
 
 ```
 sfdx force:org:open
 ```
 
-13. In **Setup**, under **Themes and Branding**, activate the **Lightning Lite** theme.
+12. In **Setup**, under **Themes and Branding**, activate the **Lightning Lite** theme.
 
-14. In **Setup**, select **All Communities**. Click on **Builder** for the _E-Bikes_ Community.
+13. In **Setup**, select **All Communities**. Click on **Builder** for the _E-Bikes_ Community.
 
-15. Click **Publish**, to publish the community. Click on the workspace icon in the top left corner, then click **View E-Bikes** to see the live community.
+14. Click **Publish**, to publish the community. Click on the workspace icon in the top left corner, then click **View E-Bikes** to see the live community.
 
-16. For experiencing the Salesforce app, open the App Launcher, and select the **E-Bikes** app.
+15. For experiencing the Salesforce app, open the App Launcher, and select the **E-Bikes** app.
 
-17. If you want to work with the application in a scratch org in the future, you'll want to switch back to the **master** branch:
+16. If you want to work with the application in a scratch org in the future, you'll want to switch back to the **master** branch:
 
 ```
 git checkout master

--- a/README.md
+++ b/README.md
@@ -90,20 +90,22 @@ sfdx force:org:open
 
 These steps assume you have followed the instructions above to install the application into a Scratch org first, and now want to deploy it to a more permanent environment, including for completion of the [Lightning Web Components Basics Trailhead module](https://trailhead.salesforce.com/content/learn/modules/lightning-web-components-basics).
 
-1. It's recommended to sign up for a [new Developer Edition org](https://developer.salesforce.com/signup), to avoid conflicts with work you may have done in any other orgs. If you created a new Developer Edition org to serve as a DevHub, and haven't done other work in the org, you can use that org. 
+1. It's recommended to sign up for a [new Developer Edition org](https://developer.salesforce.com/signup), to avoid conflicts with work you may have done in any other orgs. If you created a new Developer Edition org to serve as a DevHub, and haven't done other work in the org, you can use that org.
 
 2. Once you've logged in to the org, in **Setup**, under **My Domain**, [register a My Domain](https://help.salesforce.com/articleView?id=domain_name_setup.htm&type=5).
 
 3. In **Setup**, under **Communities Settings**, click the **Enable communities** checkbox, and then select and register a subdomain for your community.
 
-4. In **Setup**, under **Object Manager**, delete the custom **Product** picklist field from the **Case** object.  
+4. In **Setup**, under **Object Manager**, delete the custom **Product** picklist field from the **Case** object.
 
-4. At the command line, authenticate to your Developer Edition, and provide it with an alias (**ebikesDE** in the command below):
+5. At the command line, authenticate to your Developer Edition, and provide it with an alias (**ebikesDE** in the command below):
+
 ```
 sfdx force:auth:web:login -a ebikesDE
 ```
 
 5. Check out a new branch of the code, to make changes that will allow deployment to a Developer Edition org:
+
 ```
 git checkout -b devOrg
 ```
@@ -111,28 +113,32 @@ git checkout -b devOrg
 6. In VS Code, use the Ctrl/Cmd-P shortcut for Quick Open. Type **E_Bikes.site** and click on the **E_Bikes.site-meta.xml** file to open it.
 
 7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**codey<span>@</span>ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
+
 ```
     <siteAdmin>codey@ebikes.dev</siteAdmin>
     <siteType>ChatterNetwork</siteType>
-    <subdomain>codeys-ebikes-developer-edition</subdomain> 
+    <subdomain>codeys-ebikes-developer-edition</subdomain>
 ```
 
-8. Deploy the app to your Developer Edition org: 
+8. Deploy the app to your Developer Edition org:
+
 ```
 sfdx force:source:deploy -p force-app/main/default -u ebikesDE
 ```
 
 9. Follow the other deployment steps above, specifying your Developer org's alias:
+
 ```
 sfdx force:user:permset:assign -n ebikes -u ebikesDE
 sfdx force:data:tree:import --plan ./data/sample-data-plan.json -u ebikesDE
-sfdx force:mdapi:deploy -u ebikesDE --deploydir mdapiDeploy/unpackaged -w 1 
+sfdx force:mdapi:deploy -u ebikesDE --deploydir mdapiDeploy/unpackaged -w 1
 sfdx force:org:open -u ebikesDE
 ```
 
-10. Follow the manual configuration steps from above. 
+10. Follow the manual configuration steps from above.
 
 11. If you want to work with the application in a scratch org in the future, you'll want to switch back to the **master** branch:
+
 ```
 git checkout master
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,49 @@ sfdx force:org:open
 
 13. For experiencing the Salesforce app, open the App Launcher, and select the **E-Bikes** app.
 
+## Installing E-Bikes using a Developer Edition Org
+
+These steps assume you have followed the instructions above to install the application into a Scratch org first, and now want to deploy it to a more permanent environment, including for completion of the [Lightning Web Components Basics Trailhead module](https://trailhead.salesforce.com/content/learn/modules/lightning-web-components-basics).
+
+1. It's recommended to sign up for a [new Developer Edition org](https://developer.salesforce.com/signup), to avoid conflicts with work you may have done in any other orgs. 
+
+2. Once you've logged in to the org, in **Setup**, under **My Domain**, [register a My Domain](https://help.salesforce.com/articleView?id=domain_name_setup.htm&type=5).
+
+3. In **Setup**, under **Communities Settings**, click the **Enable communities** checkbox, and then select and register a domain for your community.
+
+4. At the command line, authenticate to your Developer Edition, and provide it with an alias (**ebikesDE** in the command below):
+```
+sfdx force:auth:web:login -a ebikesDE
+```
+5. Check out a new branch of the code, to make changes that will allow deployment to a Developer Edition org:
+```
+git checkout -b devOrg
+```
+
+6. In VS Code, use the Ctrl/Cmd-P shortcut for Quick Open. Type **E_Bikes.site** and click on the **E_Bikes.site-meta.xml** file to open it.
+
+7. Change the value in the **<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **<subdomain>** line to be the subdomain you selected for your Communities (**codey@ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
+```
+    <siteAdmin>codey@ebikes.dev</siteAdmin>
+    <siteType>ChatterNetwork</siteType>
+    <subdomain>codeys-ebikes-developer-edition</subdomain> 
+```
+
+5. Deploy the app to your Developer Edition org: 
+```
+sfdx force:source:deploy -p force-app/main/default -u ebikesDE
+```
+
+6. Follow the other deployment steps above, using the **ebikesDE** org alias:
+```
+sfdx force:user:permset:assign -n ebikes -u ebikesDE
+sfdx force:data:tree:import --plan ./data/sample-data-plan.json -u ebikesDE
+sfdx force:mdapi:deploy -u ebikes --deploydir mdapiDeploy/unpackaged -w 1 -u ebikesDE
+sfdx force:org:open -u ebikesDE
+```
+
+7. Follow the manual configuration steps from above. 
+
 ## Optional Installation Instructions
 
 This repository contains several files that are relevant if you want to integrate modern web development tooling to your Salesforce development processes, or to your continuous integration/continuous deployment processes.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ git checkout -b devOrg
 
 6. In VS Code, use the Ctrl/Cmd-P shortcut for Quick Open. Type **E_Bikes.site** and click on the **E_Bikes.site-meta.xml** file to open it.
 
-7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**\codey@ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
+7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**codey\@ebikes\.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
 ```
     <siteAdmin>codey@ebikes.dev</siteAdmin>
     <siteType>ChatterNetwork</siteType>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ E-Bikes is a sample application that demonstrates how to build applications with
 
 -   [Installing E-Bikes using a scratch org](#installing-e-bikes-using-a-scratch-org)
 
+-   [Installing E-Bikes using a Developer Edition Org](#installing-e-bikes-using-a-developer-edition-org)
+
 -   [Optional installation instructions](#optional-installation-instructions)
 
 -   [Salesforce Application Walkthrough](#salesforce-application-walkthrough)
@@ -88,16 +90,19 @@ sfdx force:org:open
 
 These steps assume you have followed the instructions above to install the application into a Scratch org first, and now want to deploy it to a more permanent environment, including for completion of the [Lightning Web Components Basics Trailhead module](https://trailhead.salesforce.com/content/learn/modules/lightning-web-components-basics).
 
-1. It's recommended to sign up for a [new Developer Edition org](https://developer.salesforce.com/signup), to avoid conflicts with work you may have done in any other orgs. 
+1. It's recommended to sign up for a [new Developer Edition org](https://developer.salesforce.com/signup), to avoid conflicts with work you may have done in any other orgs. If you created a new Developer Edition org to serve as a DevHub, and haven't done other work in the org, you can use that org. 
 
 2. Once you've logged in to the org, in **Setup**, under **My Domain**, [register a My Domain](https://help.salesforce.com/articleView?id=domain_name_setup.htm&type=5).
 
-3. In **Setup**, under **Communities Settings**, click the **Enable communities** checkbox, and then select and register a domain for your community.
+3. In **Setup**, under **Communities Settings**, click the **Enable communities** checkbox, and then select and register a subdomain for your community.
+
+4. In **Setup**, under **Object Manager**, delete the custom **Product** picklist field from the **Case** object.  
 
 4. At the command line, authenticate to your Developer Edition, and provide it with an alias (**ebikesDE** in the command below):
 ```
 sfdx force:auth:web:login -a ebikesDE
 ```
+
 5. Check out a new branch of the code, to make changes that will allow deployment to a Developer Edition org:
 ```
 git checkout -b devOrg
@@ -105,27 +110,32 @@ git checkout -b devOrg
 
 6. In VS Code, use the Ctrl/Cmd-P shortcut for Quick Open. Type **E_Bikes.site** and click on the **E_Bikes.site-meta.xml** file to open it.
 
-7. Change the value in the **<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **<subdomain>** line to be the subdomain you selected for your Communities (**codey@ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
+7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**\codey@ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
 ```
     <siteAdmin>codey@ebikes.dev</siteAdmin>
     <siteType>ChatterNetwork</siteType>
     <subdomain>codeys-ebikes-developer-edition</subdomain> 
 ```
 
-5. Deploy the app to your Developer Edition org: 
+8. Deploy the app to your Developer Edition org: 
 ```
 sfdx force:source:deploy -p force-app/main/default -u ebikesDE
 ```
 
-6. Follow the other deployment steps above, using the **ebikesDE** org alias:
+9. Follow the other deployment steps above, specifying your Developer org's alias:
 ```
 sfdx force:user:permset:assign -n ebikes -u ebikesDE
 sfdx force:data:tree:import --plan ./data/sample-data-plan.json -u ebikesDE
-sfdx force:mdapi:deploy -u ebikes --deploydir mdapiDeploy/unpackaged -w 1 -u ebikesDE
+sfdx force:mdapi:deploy -u ebikesDE --deploydir mdapiDeploy/unpackaged -w 1 
 sfdx force:org:open -u ebikesDE
 ```
 
-7. Follow the manual configuration steps from above. 
+10. Follow the manual configuration steps from above. 
+
+11. If you want to work with the application in a scratch org in the future, you'll want to switch back to the **master** branch:
+```
+git checkout master
+```
 
 ## Optional Installation Instructions
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sfdx force:org:open
 
 ## Installing E-Bikes using a Developer Edition Org
 
-These steps assume you have followed the instructions above to install the application into a Scratch org first, and now want to deploy it to a more permanent environment, including for completion of the [Lightning Web Components Basics Trailhead module](https://trailhead.salesforce.com/content/learn/modules/lightning-web-components-basics).
+These steps assume you have followed the instructions above to install the application into a scratch org first, and now want to deploy it to a more permanent environment, including for completion of the [Lightning Web Components Basics Trailhead module](https://trailhead.salesforce.com/content/learn/modules/lightning-web-components-basics).
 
 1. It's recommended to sign up for a [new Developer Edition org](https://developer.salesforce.com/signup), to avoid conflicts with work you may have done in any other orgs. If you created a new Developer Edition org to serve as a DevHub, and haven't done other work in the org, you can use that org.
 
@@ -115,9 +115,9 @@ git checkout -b devOrg
 7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**codey<span>@</span>ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
 
 ```
-    <siteAdmin>codey@ebikes.dev</siteAdmin>
-    <siteType>ChatterNetwork</siteType>
-    <subdomain>codeys-ebikes-developer-edition</subdomain>
+<siteAdmin>codey@ebikes.dev</siteAdmin>
+<siteType>ChatterNetwork</siteType>
+<subdomain>codeys-ebikes-developer-edition</subdomain>
 ```
 
 8. Deploy the app to your Developer Edition org:
@@ -126,18 +126,39 @@ git checkout -b devOrg
 sfdx force:source:deploy -p force-app/main/default -u ebikesDE
 ```
 
-9. Follow the other deployment steps above, specifying your Developer org's alias:
+9. Assign the **ebikes** permission set to the default user:
 
 ```
-sfdx force:user:permset:assign -n ebikes -u ebikesDE
-sfdx force:data:tree:import --plan ./data/sample-data-plan.json -u ebikesDE
-sfdx force:mdapi:deploy -u ebikesDE --deploydir mdapiDeploy/unpackaged -w 1
-sfdx force:org:open -u ebikesDE
+sfdx force:user:permset:assign -n ebikes
 ```
 
-10. Follow the manual configuration steps from above.
+10. Load sample data:
 
-11. If you want to work with the application in a scratch org in the future, you'll want to switch back to the **master** branch:
+```
+sfdx force:data:tree:import --plan ./data/sample-data-plan.json
+```
+
+11. Deploy Community metadata
+
+```
+sfdx force:mdapi:deploy -u ebikes --deploydir mdapiDeploy/unpackaged -w 1
+```
+
+12. Open the scratch org:
+
+```
+sfdx force:org:open
+```
+
+13. In **Setup**, under **Themes and Branding**, activate the **Lightning Lite** theme.
+
+14. In **Setup**, select **All Communities**. Click on **Builder** for the _E-Bikes_ Community.
+
+15. Click **Publish**, to publish the community. Click on the workspace icon in the top left corner, then click **View E-Bikes** to see the live community.
+
+16. For experiencing the Salesforce app, open the App Launcher, and select the **E-Bikes** app.
+
+17. If you want to work with the application in a scratch org in the future, you'll want to switch back to the **master** branch:
 
 ```
 git checkout master

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ git checkout -b devOrg
 
 6. In VS Code, use the Ctrl/Cmd-P shortcut for Quick Open. Type **E_Bikes.site** and click on the **E_Bikes.site-meta.xml** file to open it.
 
-7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**codey\@ebikes\.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
+7. Change the value in the **\<siteAdmin>** line to be your user name in the Developer Org, and change the value in the **\<subdomain>** line to be the subdomain you selected for your Communities (**codey<span>@</span>ebikes.dev** and **codeys-ebikes-developer-edition** in the example below). Save the file.
 ```
     <siteAdmin>codey@ebikes.dev</siteAdmin>
     <siteType>ChatterNetwork</siteType>


### PR DESCRIPTION
The merger of the ebikes-communities-lwc code into this repo makes it difficult to follow the instructions in the [Lightning Web Components Basics > Push and Deploy Lightning Web Component Files](https://trailhead.salesforce.com/content/learn/modules/lightning-web-components-basics/push-lightning-web-component-files) unit - a Dev Org isn't set up out-of-the box to have a repo with a Community deployed to it. This PR adds instructions to the README for deployment to a DevOrg. I tested them, and they work. 

I did hit one anomaly, and could certainly make an additional change if necessary, but it has to do with behavior I haven't seen before. When I got to deploying the unpackaged metadata, I got an error for `E-Bikes Profile.profile` that the User License couldn't be changed. The User License that was on the profile created by deploying the Community & Site was `Guest`, not `Guest Site User`. Changing the value in the profile XML to `Guest` worked, but I haven't seen the `Guest` User License before - is this expected? 