### PR TITLE
Update lwc-jest to sfdx-lwc-jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,6 @@ To set up the formatting and linting pre-commit hook:
 1. Install [Node.js](https://nodejs.org) if you haven't already done so
 2. Run `npm install` in your project's root folder to install the ESLint and Prettier modules (Note: Mac users should verify that Xcode command line tools are installed before running this command.)
 
-> Note: This projects also contains [Jest](https://jestjs.io) tests for unit testing Lightning Web Components. If you experience errors regarding `deasync` when running `npm install` please check out the troubleshooting information in the [lwc-jest repository](https://github.com/salesforce/lwc-jest#troubleshooting-deasync-installation-errors).
-
 Prettier and ESLint will now run automatically every time you commit changes. The commit will fail if linting errors are detected. You can also run the formatting and linting from the command line using the following commands (check out [package.json](./package.json) for the full list):
 
 ```

--- a/force-app/main/default/lwc/placeholder/__tests__/placeholder.test.js
+++ b/force-app/main/default/lwc/placeholder/__tests__/placeholder.test.js
@@ -15,7 +15,7 @@ describe('c-placeholder', () => {
         });
         document.body.appendChild(element);
         const img = element.shadowRoot.querySelector('img');
-        // By default @salesforce/lwc-jest resolves the
+        // By default @salesforce/sfdx-lwc-jest resolves the
         // @salesforce/resourceUrl/bike_assets import to "bike_assets"
         expect(img.src).toMatch(/\/bike_assets\//);
     });

--- a/force-app/main/default/lwc/productFilter/__tests__/productFilter.test.js
+++ b/force-app/main/default/lwc/productFilter/__tests__/productFilter.test.js
@@ -4,7 +4,7 @@ import { fireEvent } from 'c/pubsub';
 import {
     registerLdsTestWireAdapter,
     registerTestWireAdapter
-} from '@salesforce/lwc-jest';
+} from '@salesforce/sfdx-lwc-jest';
 import { CurrentPageReference } from 'lightning/navigation';
 import { getPicklistValues } from 'lightning/uiObjectInfoApi';
 

--- a/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
+++ b/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
@@ -4,7 +4,7 @@ import { fireEvent } from 'c/pubsub';
 import {
     registerTestWireAdapter,
     registerApexTestWireAdapter
-} from '@salesforce/lwc-jest';
+} from '@salesforce/sfdx-lwc-jest';
 import getProducts from '@salesforce/apex/ProductController.getProducts';
 import { CurrentPageReference } from 'lightning/navigation';
 

--- a/force-app/test/jest-mocks/lightning/navigation.js
+++ b/force-app/test/jest-mocks/lightning/navigation.js
@@ -1,7 +1,7 @@
 /**
  * For the original lightning/navigation mock that comes by default with
- * @salesforce/lwc-jest, see:
- * https://github.com/salesforce/lwc-jest/blob/master/src/lightning-mocks/navigation/navigation.js
+ * @salesforce/sfdx-lwc-jest, see:
+ * https://github.com/salesforce/sfdx-lwc-jest/blob/master/src/lightning-mocks/navigation/navigation.js
  */
 export const CurrentPageReference = jest.fn();
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const { jestConfig } = require('@salesforce/lwc-jest/config');
+const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
 module.exports = {
     ...jestConfig,
     moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,15 +95,24 @@
                 "@babel/types": "^7.4.4"
             },
             "dependencies": {
-                "@babel/generator": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-                    "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+                "@babel/code-frame": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                    "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.4",
+                        "@babel/highlight": "^7.0.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+                    "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.5.5",
                         "jsesc": "^2.5.1",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "source-map": "^0.5.0",
                         "trim-right": "^1.0.1"
                     }
@@ -118,62 +127,74 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-                    "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
                     "dev": true
                 },
                 "@babel/traverse": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-                    "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+                    "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.4.4",
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.5.5",
                         "@babel/helper-function-name": "^7.1.0",
                         "@babel/helper-split-export-declaration": "^7.4.4",
-                        "@babel/parser": "^7.4.5",
-                        "@babel/types": "^7.4.4",
+                        "@babel/parser": "^7.5.5",
+                        "@babel/types": "^7.5.5",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
-                        "lodash": "^4.17.11"
+                        "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-            "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+            "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
             "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.4.4",
-                "lodash": "^4.17.11"
+                "@babel/types": "^7.5.5",
+                "lodash": "^4.17.13"
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
@@ -217,25 +238,50 @@
             },
             "dependencies": {
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
-            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+            "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.5.5"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-module-imports": {
@@ -248,17 +294,17 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
-            "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+            "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.0.0",
                 "@babel/helper-simple-access": "^7.1.0",
                 "@babel/helper-split-export-declaration": "^7.4.4",
                 "@babel/template": "^7.4.4",
-                "@babel/types": "^7.4.4",
-                "lodash": "^4.17.11"
+                "@babel/types": "^7.5.5",
+                "lodash": "^4.17.13"
             },
             "dependencies": {
                 "@babel/helper-split-export-declaration": {
@@ -271,9 +317,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-                    "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
                     "dev": true
                 },
                 "@babel/template": {
@@ -288,15 +334,21 @@
                     }
                 },
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
@@ -316,12 +368,20 @@
             "dev": true
         },
         "@babel/helper-regex": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
-            "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+            "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                }
             }
         },
         "@babel/helper-remap-async-to-generator": {
@@ -338,26 +398,35 @@
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
-            "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+            "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-member-expression-to-functions": "^7.5.5",
                 "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/traverse": "^7.5.5",
+                "@babel/types": "^7.5.5"
             },
             "dependencies": {
-                "@babel/generator": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-                    "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+                "@babel/code-frame": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                    "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.4",
+                        "@babel/highlight": "^7.0.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+                    "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.5.5",
                         "jsesc": "^2.5.1",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "source-map": "^0.5.0",
                         "trim-right": "^1.0.1"
                     }
@@ -372,38 +441,44 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-                    "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
                     "dev": true
                 },
                 "@babel/traverse": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-                    "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+                    "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.4.4",
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.5.5",
                         "@babel/helper-function-name": "^7.1.0",
                         "@babel/helper-split-export-declaration": "^7.4.4",
-                        "@babel/parser": "^7.4.5",
-                        "@babel/types": "^7.4.4",
+                        "@babel/parser": "^7.5.5",
+                        "@babel/types": "^7.5.5",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
-                        "lodash": "^4.17.11"
+                        "lodash": "^4.17.13"
                     }
                 },
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
@@ -439,25 +514,25 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
-            "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
+            "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.4.4",
-                "@babel/traverse": "^7.4.4",
-                "@babel/types": "^7.4.4"
+                "@babel/traverse": "^7.5.5",
+                "@babel/types": "^7.5.5"
             },
             "dependencies": {
                 "@babel/generator": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-                    "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+                    "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.4",
+                        "@babel/types": "^7.5.5",
                         "jsesc": "^2.5.1",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "source-map": "^0.5.0",
                         "trim-right": "^1.0.1"
                     }
@@ -472,9 +547,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-                    "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
                     "dev": true
                 },
                 "@babel/template": {
@@ -489,32 +564,49 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-                    "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+                    "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.4.4",
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.5.5",
                         "@babel/helper-function-name": "^7.1.0",
                         "@babel/helper-split-export-declaration": "^7.4.4",
-                        "@babel/parser": "^7.4.5",
-                        "@babel/types": "^7.4.4",
+                        "@babel/parser": "^7.5.5",
+                        "@babel/types": "^7.5.5",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
-                        "lodash": "^4.17.11"
+                        "lodash": "^4.17.13"
+                    },
+                    "dependencies": {
+                        "@babel/code-frame": {
+                            "version": "7.5.5",
+                            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/highlight": "^7.0.0"
+                            }
+                        }
                     }
                 },
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
@@ -1143,28 +1235,28 @@
             }
         },
         "@lwc/babel-plugin-component": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-0.37.4.tgz",
-            "integrity": "sha512-MIPLKsQKaGTu19PwLexMzEQfVo9a6qvyMYc4ta3iSBaLOTA9qdL8teN5ftFEsmvWaecJt0Yc8ulQedIKnf97zg==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-0.37.4-220.2.tgz",
+            "integrity": "sha512-PHkQt3zyCRMMmACPdE9WAJ9nqp0mPdZ5LumW6sb7vZeE9Z6VeoEskZzkhUPywW+77u9pHIRawiYjbbV5gtwBNg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "7.0.0",
                 "@babel/plugin-proposal-class-properties": "7.1.0",
-                "@lwc/errors": "0.37.4"
+                "@lwc/errors": "0.37.4-220.2"
             }
         },
         "@lwc/compiler": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-0.37.4.tgz",
-            "integrity": "sha512-dHF7hmzphxarz2O/1KGg/15hpGW/WhVSLdtWSQ58jjfRAft5ORoddTJFNWGS0pE/0o1Ux6xE7uWjHOCehHjQEg==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-0.37.4-220.2.tgz",
+            "integrity": "sha512-UQ8AX8ANOx3OYjJ5iFE87oEykqBbMrFBJgOQyheNyEn5IQITXDdy/MPSV0YKbSFr8TVncJS10Tb26JfQDIftbg==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.1.0",
                 "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-                "@lwc/babel-plugin-component": "0.37.4",
-                "@lwc/errors": "0.37.4",
-                "@lwc/style-compiler": "0.37.4",
-                "@lwc/template-compiler": "0.37.4",
+                "@lwc/babel-plugin-component": "0.37.4-220.2",
+                "@lwc/errors": "0.37.4-220.2",
+                "@lwc/style-compiler": "0.37.4-220.2",
+                "@lwc/template-compiler": "0.37.4-220.2",
                 "@types/chokidar": "^1.7.5",
                 "babel-preset-compat": "0.21.4",
                 "babel-preset-minify": "0.5.0-alpha.5a128fd5",
@@ -1173,18 +1265,18 @@
             }
         },
         "@lwc/engine": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-0.37.4.tgz",
-            "integrity": "sha512-2o7Fp7U3javtSHn8M+0SzqsY/Jxv0aKk49UvPCDqUOFRoT3hkIqo+k9k6PzG6rIJpPGnJGzFD+AQOHVztpqMDg==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/engine/-/engine-0.37.4-220.2.tgz",
+            "integrity": "sha512-K/41eTS7lrew/aoN9tNOuyCnffUfKi27pF8k+D20rbQjitOn5MzAeMHN31gelprwFxcfdnGGVCc5DkpWfRhMiA==",
             "dev": true,
             "requires": {
                 "observable-membrane": "0.26.1"
             }
         },
         "@lwc/errors": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-0.37.4.tgz",
-            "integrity": "sha512-e3qb0oVuha/8raTowJkM2tD3oprcEmxO6rEc/eUefX49QlgjldxTcEdF7mHuS+LDoLzwhTLgx+2jVzL0CmhP/w==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-0.37.4-220.2.tgz",
+            "integrity": "sha512-fIetApE3x/dNo515Or1psyOta0iLQqLfq5frr9bqyorybpyqxWSPY7hyi2NX+NPXJWyjvI0g3V0vQSaKw329Kg==",
             "dev": true
         },
         "@lwc/eslint-plugin-lwc": {
@@ -1194,41 +1286,40 @@
             "dev": true
         },
         "@lwc/jest-preset": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-0.37.4.tgz",
-            "integrity": "sha512-a0dKXbZalEHwhShCyiP8mxn7zhxnQMzcawcVClRKy2uebFTrU9JisloiC2vDLLinsgdWgtr2+Wd3ftV802nM2Q==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-0.37.4-220.2.tgz",
+            "integrity": "sha512-rMXsa3NPFzwZl5Cbx+0jZfINo+w5ZcJOYWz/odjL2hu1Z1RF9QPAReS1Q9+JxVe2dL9kfVB0h2BHMN7UXe924Q==",
             "dev": true,
             "requires": {
-                "@lwc/jest-resolver": "0.37.4",
-                "@lwc/jest-serializer": "0.37.4",
-                "@lwc/jest-transformer": "0.37.4",
-                "@lwc/test-utils": "0.37.4"
+                "@lwc/jest-resolver": "0.37.4-220.2",
+                "@lwc/jest-serializer": "0.37.4-220.2",
+                "@lwc/jest-transformer": "0.37.4-220.2",
+                "@lwc/test-utils": "0.37.4-220.2"
             }
         },
         "@lwc/jest-resolver": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-0.37.4.tgz",
-            "integrity": "sha512-NsNo6+d3+f+AMXDG8d46AffMD2Crt78naYJ8QkK7Dze5J4JLc7QviBHIUpj9Iq8isk0cjhVsgMEqHyjxh6Wv8A==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-0.37.4-220.2.tgz",
+            "integrity": "sha512-Q7Gb+2TQ4Mhl8l290SPM7+sCN7r6pb+f6zaHvYnPWcON6KXXxy3/Klj33kvvqnrjLC2QoZCRtXy6p/1zsSedng==",
             "dev": true
         },
         "@lwc/jest-serializer": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-0.37.4.tgz",
-            "integrity": "sha512-B3DHR0KWJuji4jnDh373t2ps7FikY5AFveb62iWovhT9xgyiEWMEdAArxxEtc/z5upG6w4w6fWMnMdoinm2pog==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-0.37.4-220.2.tgz",
+            "integrity": "sha512-BEBWhlNSA3c2340LSXGUNHWEpRfkVDtTqZjaYrKfKfw4yZaflhfbtuBuIfynT8WERL8491W2STmLnojeqpmkew==",
             "dev": true
         },
         "@lwc/jest-transformer": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-0.37.4.tgz",
-            "integrity": "sha512-qa0H1+E9tsmQN/vDxxC4fE9pCMxOOQC2T+1VJSquNBHzXemGFonHp3d1GvtjKF+kd7kdMHwYd/OFsNebpbO8IA==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-0.37.4-220.2.tgz",
+            "integrity": "sha512-v1lyri+bi1e4RmuXZXbjlPSDJLLzSRwNVYrcJLic6yY4H44ib2E8T7ofgLpHFZfXng+arfXGxIjQ8PAUcdotkw==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.1.0",
                 "@babel/plugin-transform-modules-commonjs": "7.1.0",
                 "@babel/template": "~7.1.2",
-                "@lwc/errors": "0.37.4",
-                "babel-preset-jest": "^24.0.0",
-                "deasync": "0.1.14"
+                "@lwc/errors": "0.37.4-220.2",
+                "babel-preset-jest": "^24.0.0"
             },
             "dependencies": {
                 "@babel/template": {
@@ -1245,18 +1336,18 @@
             }
         },
         "@lwc/module-resolver": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-0.37.4.tgz",
-            "integrity": "sha512-Dz1hW9moypCU67WzQRcOEg4J6kNn1rSaota/s3ppy/pTeQFsqYJynFZTNNrhribQMx6+u/WXFKwqCkB6r8tOQw==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-0.37.4-220.2.tgz",
+            "integrity": "sha512-tycKV4OjFXYEWEiBt4De2C0Vz6cSXtdTQPAH9UyF94TNfkSZlC5Xk+pfoRNBByvvdnsF82MZFo5cYEtu+XQlQw==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2"
             }
         },
         "@lwc/style-compiler": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-0.37.4.tgz",
-            "integrity": "sha512-rveeuf2tv3lL2iXqPidwz7MMuRr3TqZo0Pj8N7Ee/puG49d4JKnCTZkp+x4lYpksuYNKdLf8TCpq+15K0xOGwQ==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-0.37.4-220.2.tgz",
+            "integrity": "sha512-3hsCu1QXdEpvxjAIgpa3h2RnreIT0A+ER3ysW8RWe6N+vgeEIniJv6YXY+X8Ot/7VoVPmnHuFwFh+TatwOlqQw==",
             "dev": true,
             "requires": {
                 "cssnano": "~3.10.0",
@@ -1266,9 +1357,9 @@
             }
         },
         "@lwc/template-compiler": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-0.37.4.tgz",
-            "integrity": "sha512-/JqAs6Jn5n7JwA9ZFGJBg+f3DtFj0K+3o8IOuUgrKtoTMKrCzF6k4GtuG29g3WR+4//MAWnF1vHLHjkZJTvwoQ==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-0.37.4-220.2.tgz",
+            "integrity": "sha512-MIhn3PrSgQSq0tCT06ukIIMS7icIhQEpj/tRFiW/VOjjUsDYUSDTxa/VF6vCMnoRIuxVvhWFzIz27B88p4zWqQ==",
             "dev": true,
             "requires": {
                 "@babel/generator": "~7.1.5",
@@ -1276,8 +1367,8 @@
                 "@babel/template": "~7.1.2",
                 "@babel/traverse": "~7.1.5",
                 "@babel/types": "~7.1.5",
-                "@lwc/errors": "0.37.4",
-                "@lwc/style-compiler": "0.37.4",
+                "@lwc/errors": "0.37.4-220.2",
+                "@lwc/style-compiler": "0.37.4-220.2",
                 "camelcase": "~5.0.0",
                 "he": "^1.1.1",
                 "parse5-with-errors": "^4.0.1"
@@ -1344,15 +1435,15 @@
             }
         },
         "@lwc/test-utils": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/test-utils/-/test-utils-0.37.4.tgz",
-            "integrity": "sha512-5yQeW3dl+MdbCrwzmxgIRuT4xHro9FMtomCB0FZDFD0Z6Om+ekCSYiBCwvjU3qCNzmjI6Xime9rFEFIHda2zvw==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/test-utils/-/test-utils-0.37.4-220.2.tgz",
+            "integrity": "sha512-grrOqEwjO2mkKc5O4t3SA64lCVbKWT0G70tNfvq6BSYtakfXmES+cKFAb8x2s3U4Nc3bMcBf0HFhnXnCbIuQgg==",
             "dev": true
         },
         "@lwc/wire-service": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-0.37.4.tgz",
-            "integrity": "sha512-GTu9G7fFzdbzBalPNnzLGMNtSv/61KkBhbRtE5ku1ByYIqucQYIpatx64aLvYl7+Fm34NjTZiVS44CkR8GcMQA==",
+            "version": "0.37.4-220.2",
+            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-0.37.4-220.2.tgz",
+            "integrity": "sha512-WzuV2J+zvE1z480DXy+ohLrp7J6PlXXfhKeT7fqxq/RHeKHnVaoOhYm81RCPpKIV2pgzBPhdopgj8gGNjfPIIQ==",
             "dev": true
         },
         "@salesforce/eslint-config-lwc": {
@@ -1367,20 +1458,20 @@
                 "eslint-plugin-jest": "^22.0.0"
             }
         },
-        "@salesforce/lwc-jest": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@salesforce/lwc-jest/-/lwc-jest-0.5.0.tgz",
-            "integrity": "sha512-98KQLWwJP4m+osAv7HF44Ps2bL5RWs5ANek2B4+GtbItv+iU0Q4yFJq5X9JFiaZj0W2TSHJIQYkYZaN5wjPLAg==",
+        "@salesforce/sfdx-lwc-jest": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@salesforce/sfdx-lwc-jest/-/sfdx-lwc-jest-0.5.4.tgz",
+            "integrity": "sha512-CcPrXGECEl6TR9qNu3mG8q4PxNoT0YUMvDVihwazw1/kAQhYVrYtMUB3gBuxJDoKM9azvhr2wsKxE4ZMGuQnIg==",
             "dev": true,
             "requires": {
-                "@lwc/compiler": "0.37.4",
-                "@lwc/engine": "0.37.4",
-                "@lwc/jest-preset": "0.37.4",
-                "@lwc/jest-resolver": "0.37.4",
-                "@lwc/jest-serializer": "0.37.4",
-                "@lwc/jest-transformer": "0.37.4",
-                "@lwc/module-resolver": "0.37.4",
-                "@lwc/wire-service": "0.37.4",
+                "@lwc/compiler": "0.37.4-220.2",
+                "@lwc/engine": "0.37.4-220.2",
+                "@lwc/jest-preset": "0.37.4-220.2",
+                "@lwc/jest-resolver": "0.37.4-220.2",
+                "@lwc/jest-serializer": "0.37.4-220.2",
+                "@lwc/jest-transformer": "0.37.4-220.2",
+                "@lwc/module-resolver": "0.37.4-220.2",
+                "@lwc/wire-service": "0.37.4-220.2",
                 "@salesforce/wire-service-jest-util": "^2.2.5",
                 "chalk": "^2.3.0",
                 "glob": "^7.1.2",
@@ -1492,9 +1583,9 @@
             }
         },
         "@types/node": {
-            "version": "6.14.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
-            "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w==",
+            "version": "6.14.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz",
+            "integrity": "sha512-YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -1528,9 +1619,9 @@
             "dev": true
         },
         "acorn-globals": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-            "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+            "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.1",
@@ -1538,9 +1629,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.1.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-                    "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+                    "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
                     "dev": true
                 }
             }
@@ -1552,9 +1643,9 @@
             "dev": true
         },
         "acorn-walk": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
             "dev": true
         },
         "ajv": {
@@ -1700,9 +1791,9 @@
             "dev": true
         },
         "async-limiter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
             "dev": true
         },
         "asynckit": {
@@ -1871,11 +1962,12 @@
             }
         },
         "babel-plugin-istanbul": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-            "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+            "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
             "dev": true,
             "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
                 "find-up": "^3.0.0",
                 "istanbul-lib-instrument": "^3.3.0",
                 "test-exclude": "^5.2.3"
@@ -2278,12 +2370,6 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "bindings": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-            "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2357,9 +2443,9 @@
             }
         },
         "bser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+            "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
@@ -2414,7 +2500,7 @@
         },
         "callsites": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
             "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
             "dev": true
         },
@@ -2437,9 +2523,9 @@
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000974",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000974.tgz",
-            "integrity": "sha512-zeXkn1hbjMvXdadcyUELZnGu7OjlW3HK0956DWczM7ZJqGV4jFaPi8CidB8QiAj5xl5O9I+f7j9F0AFmXmGTpg==",
+            "version": "1.0.30000989",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000989.tgz",
+            "integrity": "sha512-5pkU/t9nueoBgELZOCpK+wN4wK6MkIz1Q9lGZSgLwg4xR8EhLY9r0qj6T2bUI8Cq9pGbioEar+Zqgosk5fpbjg==",
             "dev": true
         },
         "capture-exit": {
@@ -2569,7 +2655,7 @@
                 },
                 "slice-ansi": {
                     "version": "0.0.4",
-                    "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
                     "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
                     "dev": true
                 },
@@ -2937,15 +3023,15 @@
             }
         },
         "cssom": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-            "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
             "dev": true
         },
         "cssstyle": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-            "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+            "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
             "dev": true,
             "requires": {
                 "cssom": "0.3.x"
@@ -2989,16 +3075,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
             "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
             "dev": true
-        },
-        "deasync": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.14.tgz",
-            "integrity": "sha512-wN8sIuEqIwyQh72AG7oY6YQODCxIp1eXzEZlZznBuwDF8Q03Tdy9QNp1BNZXeadXoklNrw+Ip1fch+KXo/+ASw==",
-            "dev": true,
-            "requires": {
-                "bindings": "~1.2.1",
-                "node-addon-api": "^1.6.0"
-            }
         },
         "debug": {
             "version": "4.1.1",
@@ -3131,7 +3207,7 @@
         },
         "doctrine": {
             "version": "1.5.0",
-            "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
             "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
             "dev": true,
             "requires": {
@@ -3159,9 +3235,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.158",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.158.tgz",
-            "integrity": "sha512-wJsJaWsViNQ129XPGmyO5gGs1jPMHr9vffjHAhUje1xZbEzQcqbENdvfyRD9q8UF0TgFQFCCUbaIpJarFbvsIg==",
+            "version": "1.3.220",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.220.tgz",
+            "integrity": "sha512-ZsaFWi+9J9Nsm4OmGM/BvZF3HEeZL4bte1+CcN9vHUcqdkOOVAXP4SeacPZ/W5uCQZEKPYBXg6yUjZx8/jpD0Q==",
             "dev": true
         },
         "elegant-spinner": {
@@ -4525,7 +4601,7 @@
         },
         "globby": {
             "version": "6.1.0",
-            "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
@@ -5226,7 +5302,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -5387,14 +5463,14 @@
             },
             "dependencies": {
                 "@babel/generator": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
-                    "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+                    "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.4",
+                        "@babel/types": "^7.5.5",
                         "jsesc": "^2.5.1",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "source-map": "^0.5.0",
                         "trim-right": "^1.0.1"
                     }
@@ -5409,9 +5485,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-                    "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+                    "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
                     "dev": true
                 },
                 "@babel/template": {
@@ -5426,32 +5502,49 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.4.5",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-                    "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+                    "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.4.4",
+                        "@babel/code-frame": "^7.5.5",
+                        "@babel/generator": "^7.5.5",
                         "@babel/helper-function-name": "^7.1.0",
                         "@babel/helper-split-export-declaration": "^7.4.4",
-                        "@babel/parser": "^7.4.5",
-                        "@babel/types": "^7.4.4",
+                        "@babel/parser": "^7.5.5",
+                        "@babel/types": "^7.5.5",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0",
-                        "lodash": "^4.17.11"
+                        "lodash": "^4.17.13"
+                    },
+                    "dependencies": {
+                        "@babel/code-frame": {
+                            "version": "7.5.5",
+                            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/highlight": "^7.0.0"
+                            }
+                        }
                     }
                 },
                 "@babel/types": {
-                    "version": "7.4.4",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-                    "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+                    "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
                 }
             }
         },
@@ -5713,9 +5806,9 @@
             "dev": true
         },
         "jest-haste-map": {
-            "version": "24.8.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
-            "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+            "version": "24.8.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+            "integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
             "dev": true,
             "requires": {
                 "@jest/types": "^24.8.0",
@@ -6406,7 +6499,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -6458,7 +6551,7 @@
         },
         "load-json-file": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
@@ -6581,9 +6674,9 @@
             }
         },
         "magic-string": {
-            "version": "0.25.2",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
-            "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
+            "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
             "dev": true,
             "requires": {
                 "sourcemap-codec": "^1.4.4"
@@ -6742,7 +6835,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
@@ -6769,7 +6862,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -6832,12 +6925,6 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
-        "node-addon-api": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
-            "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg==",
-            "dev": true
-        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6851,9 +6938,9 @@
             "dev": true
         },
         "node-notifier": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-            "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.1.tgz",
+            "integrity": "sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==",
             "dev": true,
             "requires": {
                 "growly": "^1.3.0",
@@ -7111,7 +7198,7 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -7233,7 +7320,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -7272,7 +7359,7 @@
         },
         "pify": {
             "version": "2.3.0",
-            "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
             "dev": true
         },
@@ -9108,9 +9195,9 @@
             "dev": true
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "progress": {
@@ -9120,13 +9207,13 @@
             "dev": true
         },
         "prompts": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-            "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+            "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
             "dev": true,
             "requires": {
-                "kleur": "^3.0.2",
-                "sisteransi": "^1.0.0"
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.3"
             }
         },
         "property-expr": {
@@ -9142,9 +9229,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.32",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-            "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+            "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
             "dev": true
         },
         "pump": {
@@ -9186,9 +9273,9 @@
             }
         },
         "react-is": {
-            "version": "16.8.6",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+            "version": "16.9.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+            "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
             "dev": true
         },
         "read-pkg": {
@@ -9567,7 +9654,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -9689,9 +9776,9 @@
             }
         },
         "sisteransi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-            "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+            "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
             "dev": true
         },
         "slash": {
@@ -9862,9 +9949,9 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -9886,9 +9973,9 @@
             "dev": true
         },
         "sourcemap-codec": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-            "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+            "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
             "dev": true
         },
         "spdx-correct": {
@@ -9934,7 +10021,7 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
@@ -10082,7 +10169,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -10097,7 +10184,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
@@ -10336,7 +10423,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@salesforce/eslint-config-lwc": "^0.3.0",
-        "@salesforce/lwc-jest": "^0.5.0",
+        "@salesforce/sfdx-lwc-jest": "^0.5.4",
         "eslint": "^5.16.0",
         "husky": "^2.4.1",
         "lint-staged": "^8.2.0",


### PR DESCRIPTION
`@salesforce/lwc-jest` was renamed to `@salesforce/sfdx-lwc-jest`. We should update all references in the sample apps we own now since we only plan to keep the lwc-jest NPM package updated through Winter '20.

Related to https://github.com/salesforce/sfdx-lwc-jest/issues/62