### PR TITLE
Updated CI and tools

### DIFF
--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -12,7 +12,7 @@ on:
 
 # Jobs to be executed
 jobs:
-    formatting-and-lwc-tests:
+    format-lint-lwc-tests:
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -55,7 +55,7 @@ jobs:
 
     scratch-org-test:
         runs-on: ubuntu-latest
-        needs: formatting-and-lwc-tests
+        needs: format-lint-lwc-tests
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -1,5 +1,5 @@
 # Unique name for this workflow
-name: CI on Pre-release Pull Request
+name: CI on Pre-release PR
 
 # Definition when the workflow should run
 on:

--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -1,11 +1,11 @@
 # Unique name for this workflow
-name: Salesforce DX PR (scratch org)
+name: CI on Pre-release Pull Request
 
 # Definition when the workflow should run
 on:
     pull_request:
         types: [opened, edited, synchronize, reopened]
-        branches-ignore:
+        branches:
             - prerelease/spring[2-9][0-9]
             - prerelease/summer[2-9][0-9]
             - prerelease/winter[2-9][0-9]
@@ -15,12 +15,12 @@ jobs:
     formatting-and-linting:
         runs-on: ubuntu-latest
         steps:
-            # Checkout the code in the pull request
+            # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
 
             # Cache node_modules to speed up the process
-            - name: Restore node_modules cache
+            - name: 'Restore node_modules cache'
               id: cache-npm
               uses: actions/cache@v1
               with:
@@ -43,7 +43,7 @@ jobs:
             - name: 'Lint Lightning Web Components'
               run: npm run lint:lwc
 
-            # Unit tests
+            # LWC unit tests
             - name: 'Unit test Lightning Web Components'
               run: npm run test:unit:coverage
 
@@ -58,51 +58,45 @@ jobs:
         needs: formatting-and-linting
         steps:
             # Install Salesforce CLI
-            - name: Install Salesforce CLI
+            - name: 'Install Salesforce CLI'
               run: |
                   wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
                   mkdir sfdx-cli
                   tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
                   ./sfdx-cli/install
 
-            # Checkout the code in the pull request
+            # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'
               shell: bash
-              run: 'echo ${{ secrets.DEVHUB_SFDX_URL}} > ./DEVHUB_SFDX_URL.txt'
+              run: echo ${{ secrets.DEVHUB_SFDX_URL}} > ./DEVHUB_SFDX_URL.txt
 
             # Authenticate dev hub
             - name: 'Authenticate Dev Hub'
-              run: 'sfdx auth:sfdxurl:store -f ./DEVHUB_SFDX_URL.txt -a devhub -d'
+              run: sfdx auth:sfdxurl:store -f ./DEVHUB_SFDX_URL.txt -a devhub -d
 
             # Create scratch org
             - name: 'Create scratch org'
-              run: 'sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1'
-
-            # Wait for package replication
-            - name: 'Wait for two min for Communities activation'
-              uses: maddox/actions/sleep@master
-              with:
-                  args: 120
+              run: sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1 release=Preview
 
             # Deploy source to scratch org
             - name: 'Push source to scratch org'
-              run: 'sfdx force:source:push'
+              run: sfdx force:source:push
 
             # Assign permissionset
             - name: 'Assign permissionset to default user'
-              run: 'sfdx force:user:permset:assign -n ebikes'
+              run: sfdx force:user:permset:assign -n ebikes
 
             # Import sample data
             - name: 'Import sample data'
-              run: 'sfdx force:data:tree:import -p ./data/sample-data-plan.json'
+              run: sfdx force:data:tree:import -p ./data/sample-data-plan.json
 
             # Run Apex tests in scratch org
             - name: 'Run Apex tests'
-              run: 'sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20'
+              run: sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20
 
             # Upload code coverage data
             - name: 'Upload code coverage for Apex to Codecov.io'
@@ -113,4 +107,4 @@ jobs:
             # Housekeeping
             - name: 'Delete scratch org'
               if: always()
-              run: 'sfdx force:org:delete -p -u scratch-org'
+              run: sfdx force:org:delete -p -u scratch-org

--- a/.github/workflows/ci-pr-prerelease.yml
+++ b/.github/workflows/ci-pr-prerelease.yml
@@ -12,7 +12,7 @@ on:
 
 # Jobs to be executed
 jobs:
-    formatting-and-linting:
+    formatting-and-lwc-tests:
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -55,7 +55,7 @@ jobs:
 
     scratch-org-test:
         runs-on: ubuntu-latest
-        needs: formatting-and-linting
+        needs: formatting-and-lwc-tests
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,7 +12,7 @@ on:
 
 # Jobs to be executed
 jobs:
-    formatting-and-lwc-tests:
+    format-lint-lwc-tests:
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -55,7 +55,7 @@ jobs:
 
     scratch-org-test:
         runs-on: ubuntu-latest
-        needs: formatting-and-lwc-tests
+        needs: format-lint-lwc-tests
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,5 +1,5 @@
 # Unique name for this workflow
-name: CI on Pull Request
+name: CI on PR
 
 # Definition when the workflow should run
 on:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,11 +1,11 @@
 # Unique name for this workflow
-name: Salesforce DX Prerelease (scratch org)
+name: CI on Pull Request
 
 # Definition when the workflow should run
 on:
     pull_request:
         types: [opened, edited, synchronize, reopened]
-        branches:
+        branches-ignore:
             - prerelease/spring[2-9][0-9]
             - prerelease/summer[2-9][0-9]
             - prerelease/winter[2-9][0-9]
@@ -15,12 +15,12 @@ jobs:
     formatting-and-linting:
         runs-on: ubuntu-latest
         steps:
-            # Checkout the code in the pull request
+            # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
 
             # Cache node_modules to speed up the process
-            - name: Restore node_modules cache
+            - name: 'Restore node_modules cache'
               id: cache-npm
               uses: actions/cache@v1
               with:
@@ -43,7 +43,7 @@ jobs:
             - name: 'Lint Lightning Web Components'
               run: npm run lint:lwc
 
-            # Unit tests
+            # LWC unit tests
             - name: 'Unit test Lightning Web Components'
               run: npm run test:unit:coverage
 
@@ -59,44 +59,50 @@ jobs:
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'
-              run: 'sudo npm install -g sfdx-cli'
+              run: |
+                  wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+                  mkdir sfdx-cli
+                  tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+                  ./sfdx-cli/install
 
-            # Install salesforcedx pre-release plugin
-            - name: 'Install salesforcedx pre-release plugin'
-              run: 'sfdx plugins:install salesforcedx@pre-release'
-
-            # Checkout the code in the pull request
+            # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
 
             # Store secret for dev hub
-            - name: 'Populate auth file with DEVHUB_PREREL_SFDX_URL secret'
+            - name: 'Populate auth file with DEVHUB_SFDX_URL secret'
               shell: bash
-              run: 'echo ${{ secrets.DEVHUB_PREREL_SFDX_URL}} > ./DEVHUB_SFDX_URL.txt'
+              run: echo ${{ secrets.DEVHUB_SFDX_URL}} > ./DEVHUB_SFDX_URL.txt
 
             # Authenticate dev hub
             - name: 'Authenticate Dev Hub'
-              run: 'sfdx auth:sfdxurl:store -f ./DEVHUB_SFDX_URL.txt -a devhub -d'
+              run: sfdx auth:sfdxurl:store -f ./DEVHUB_SFDX_URL.txt -a devhub -d
 
             # Create scratch org
             - name: 'Create scratch org'
-              run: 'sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1'
+              run: sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1
+
+            # Wait for package replication
+            - name: 'Wait for two min for Communities activation'
+              uses: maddox/actions/sleep@master
+              with:
+                  args: 120
 
             # Deploy source to scratch org
             - name: 'Push source to scratch org'
-              run: 'sfdx force:source:push'
+              run: sfdx force:source:push
 
             # Assign permissionset
             - name: 'Assign permissionset to default user'
-              run: 'sfdx force:user:permset:assign -n ebikes'
+              run: sfdx force:user:permset:assign -n ebikes
 
             # Import sample data
             - name: 'Import sample data'
-              run: 'sfdx force:data:tree:import -p ./data/sample-data-plan.json'
+              run: sfdx force:data:tree:import -p ./data/sample-data-plan.json
 
             # Run Apex tests in scratch org
             - name: 'Run Apex tests'
-              run: 'sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20'
+              run: sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20
 
             # Upload code coverage data
             - name: 'Upload code coverage for Apex to Codecov.io'
@@ -107,4 +113,4 @@ jobs:
             # Housekeeping
             - name: 'Delete scratch org'
               if: always()
-              run: 'sfdx force:org:delete -p -u scratch-org'
+              run: sfdx force:org:delete -p -u scratch-org

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,7 +12,7 @@ on:
 
 # Jobs to be executed
 jobs:
-    formatting-and-linting:
+    formatting-and-lwc-tests:
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -55,7 +55,7 @@ jobs:
 
     scratch-org-test:
         runs-on: ubuntu-latest
-        needs: formatting-and-linting
+        needs: formatting-and-lwc-tests
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Unique name for this workflow
-name: Salesforce DX (scratch org)
+name: CI
 
 # Definition when the workflow should run
 on:
@@ -12,12 +12,12 @@ jobs:
     formatting-and-linting:
         runs-on: ubuntu-latest
         steps:
-            # Checkout the code in the pull request
+            # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
 
             # Cache node_modules to speed up the process
-            - name: Restore node_modules cache
+            - name: 'Restore node_modules cache'
               id: cache-npm
               uses: actions/cache@v1
               with:
@@ -40,7 +40,7 @@ jobs:
             - name: 'Lint Lightning Web Components'
               run: npm run lint:lwc
 
-            # Unit tests
+            # LWC unit tests
             - name: 'Unit test Lightning Web Components'
               run: npm run test:unit:coverage
 
@@ -55,29 +55,29 @@ jobs:
         needs: formatting-and-linting
         steps:
             # Install Salesforce CLI
-            - name: Install Salesforce CLI
+            - name: 'Install Salesforce CLI'
               run: |
                   wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
                   mkdir sfdx-cli
                   tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
                   ./sfdx-cli/install
 
-            # Checkout the code in the pull request
+            # Checkout the source code
             - name: 'Checkout source code'
               uses: actions/checkout@v2
 
             # Store secret for dev hub
             - name: 'Populate auth file with DEVHUB_SFDX_URL secret'
               shell: bash
-              run: 'echo ${{ secrets.DEVHUB_SFDX_URL}} > ./DEVHUB_SFDX_URL.txt'
+              run: echo ${{ secrets.DEVHUB_SFDX_URL}} > ./DEVHUB_SFDX_URL.txt
 
             # Authenticate dev hub
             - name: 'Authenticate Dev Hub'
-              run: 'sfdx auth:sfdxurl:store -f ./DEVHUB_SFDX_URL.txt -a devhub -d'
+              run: sfdx auth:sfdxurl:store -f ./DEVHUB_SFDX_URL.txt -a devhub -d
 
             # Create scratch org
             - name: 'Create scratch org'
-              run: 'sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1'
+              run: sfdx force:org:create -f config/project-scratch-def.json -a scratch-org -s -d 1
 
             # Wait for package replication
             - name: 'Wait for two min for Communities activation'
@@ -87,19 +87,19 @@ jobs:
 
             # Deploy source to scratch org
             - name: 'Push source to scratch org'
-              run: 'sfdx force:source:push'
+              run: sfdx force:source:push
 
             # Assign permissionset
             - name: 'Assign permissionset to default user'
-              run: 'sfdx force:user:permset:assign -n ebikes'
+              run: sfdx force:user:permset:assign -n ebikes
 
             # Import sample data
             - name: 'Import sample data'
-              run: 'sfdx force:data:tree:import -p ./data/sample-data-plan.json'
+              run: sfdx force:data:tree:import -p ./data/sample-data-plan.json
 
             # Run Apex tests in scratch org
             - name: 'Run Apex tests'
-              run: 'sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20'
+              run: sfdx force:apex:test:run -c -r human -d ./tests/apex -w 20
 
             # Upload code coverage data
             - name: 'Upload code coverage for Apex to Codecov.io'
@@ -110,4 +110,4 @@ jobs:
             # Housekeeping
             - name: 'Delete scratch org'
               if: always()
-              run: 'sfdx force:org:delete -p -u scratch-org'
+              run: sfdx force:org:delete -p -u scratch-org

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 # Jobs to be executed
 jobs:
-    formatting-and-lwc-tests:
+    format-lint-lwc-tests:
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -52,7 +52,7 @@ jobs:
 
     scratch-org-test:
         runs-on: ubuntu-latest
-        needs: formatting-and-lwc-tests
+        needs: format-lint-lwc-tests
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 # Jobs to be executed
 jobs:
-    formatting-and-linting:
+    formatting-and-lwc-tests:
         runs-on: ubuntu-latest
         steps:
             # Checkout the source code
@@ -52,7 +52,7 @@ jobs:
 
     scratch-org-test:
         runs-on: ubuntu-latest
-        needs: formatting-and-linting
+        needs: formatting-and-lwc-tests
         steps:
             # Install Salesforce CLI
             - name: 'Install Salesforce CLI'

--- a/.github/workflows/codetour-watch.yml
+++ b/.github/workflows/codetour-watch.yml
@@ -12,6 +12,6 @@ jobs:
               uses: actions/checkout@v2
 
             - name: 'Watch CodeTour changes'
-              uses: pozil/codetour-watch@v1.0.1
+              uses: pozil/codetour-watch@v1.1.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # E-Bikes Lightning Web Components Sample Application
 
-[![Github Workflow](<https://github.com/trailheadapps/ebikes-lwc/workflows/Salesforce%20DX%20(scratch%20org)/badge.svg?branch=master>)](https://github.com/trailheadapps/ebikes-lwc/actions?query=workflow%3A%22Salesforce+DX+%28scratch+org%29%22) [![codecov](https://codecov.io/gh/trailheadapps/ebikes-lwc/branch/master/graph/badge.svg)](https://codecov.io/gh/trailheadapps/ebikes-lwc)
+[![CI Workflow](https://github.com/trailheadapps/ebikes-lwc/workflows/CI/badge.svg)](https://github.com/trailheadapps/ebikes-lwc/actions?query=workflow%3ACI) [![codecov](https://codecov.io/gh/trailheadapps/ebikes-lwc/branch/master/graph/badge.svg)](https://codecov.io/gh/trailheadapps/ebikes-lwc)
 
 ![ebikes-logo](ebikes-logo.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
             "hasInstallScript": true,
             "license": "CC0-1.0",
             "devDependencies": {
-                "@prettier/plugin-xml": "^0.13.0",
+                "@prettier/plugin-xml": "^0.13.1",
                 "@sa11y/jest": "^0.3.0",
-                "@salesforce/eslint-config-lwc": "^0.9.0",
+                "@salesforce/eslint-config-lwc": "^0.11.0",
                 "@salesforce/sfdx-lwc-jest": "^0.10.4",
-                "eslint": "^7.21.0",
+                "eslint": "^7.22.0",
                 "eslint-config-prettier": "^8.1.0",
-                "husky": "^5.1.3",
+                "husky": "^5.2.0",
                 "prettier": "^2.2.1",
                 "prettier-plugin-apex": "^1.8.0",
                 "semver": "^7.3.4"
@@ -2155,15 +2155,19 @@
             "dev": true
         },
         "node_modules/@lwc/eslint-plugin-lwc": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.11.0.tgz",
-            "integrity": "sha512-wJOD4XWOH91GaZfypMSKfEeMXqMfvKdsb2gSJ/9FEwJVlziKg1aagtRYJh2ln3DyEZV33tBC/p/dWzIeiwa1tg==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.12.2.tgz",
+            "integrity": "sha512-6BBp3bDAhf3no/cRADIlP3/dVm4eZ48sVwC/qYuRKnB843Qu1+rP4yzmZmTivApbetFkE+HN3ZQwcoMzj/smKw==",
             "dev": true,
             "dependencies": {
                 "minimatch": "^3.0.4"
             },
             "engines": {
                 "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "babel-eslint": "^10",
+                "eslint": "^6 || ^7"
             }
         },
         "node_modules/@lwc/jest-preset": {
@@ -2597,9 +2601,9 @@
             }
         },
         "node_modules/@prettier/plugin-xml": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-0.13.0.tgz",
-            "integrity": "sha512-kjC8ZoqrNdSGyUfGS0KGxmA2YxI/mpO2bQtOsg8663DISyfvkN/1LoR8nO+0BaAKkGWhP2rzgk6rqiSEQz8vQw==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-0.13.1.tgz",
+            "integrity": "sha512-jJbjvFEsxOT2Jhv2yydOvJbnSREJy+OECwHyZaYr05jLXlJeBrzy5YY1fDYpwTfKk1B2YqNExXI+x3Zm5yGfeA==",
             "dev": true,
             "dependencies": {
                 "@xml-tools/parser": "^1.0.2",
@@ -2692,12 +2696,13 @@
             }
         },
         "node_modules/@salesforce/eslint-config-lwc": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-0.9.0.tgz",
-            "integrity": "sha512-9O3UG5A9UW9Rga3OYadViO8bu8kMZLA0hjoUd14EkwVNfYypu6XkJH2QElaIPngSAmbVOdq5wh3hrtv2F5TQyw==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-0.11.0.tgz",
+            "integrity": "sha512-f1T92ZGXrURXRiMskci26ySb7o+gQR8Ycq6L+y2Q4U0GdeUAoHKnalvL/jQiXZ3eq6KLoKPv24gfeYfn6LJcgA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@lwc/eslint-plugin-lwc": "~0.11.0",
+                "@lwc/eslint-plugin-lwc": "~0.12.2",
                 "babel-eslint": "~10.1.0",
                 "eslint-plugin-import": "~2.22.1",
                 "eslint-plugin-jest": "~23.8.2",
@@ -2705,6 +2710,9 @@
             },
             "engines": {
                 "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^6 || ^7"
             }
         },
         "node_modules/@salesforce/sfdx-lwc-jest": {
@@ -6476,9 +6484,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-            "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+            "version": "7.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+            "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
@@ -6498,7 +6506,7 @@
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^5.0.0",
-                "globals": "^12.1.0",
+                "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
@@ -6506,7 +6514,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -6759,15 +6767,18 @@
             }
         },
         "node_modules/eslint/node_modules/globals": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+            "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
             "dev": true,
             "dependencies": {
-                "type-fest": "^0.8.1"
+                "type-fest": "^0.20.2"
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint/node_modules/has-flag": {
@@ -6840,6 +6851,18 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/eslint/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/espree": {
@@ -7768,9 +7791,9 @@
             }
         },
         "node_modules/husky": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.3.tgz",
-            "integrity": "sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-5.2.0.tgz",
+            "integrity": "sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg==",
             "dev": true,
             "funding": [
                 {
@@ -11197,9 +11220,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "node_modules/lodash.memoize": {
@@ -18096,9 +18119,9 @@
             "dev": true
         },
         "@lwc/eslint-plugin-lwc": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.11.0.tgz",
-            "integrity": "sha512-wJOD4XWOH91GaZfypMSKfEeMXqMfvKdsb2gSJ/9FEwJVlziKg1aagtRYJh2ln3DyEZV33tBC/p/dWzIeiwa1tg==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.12.2.tgz",
+            "integrity": "sha512-6BBp3bDAhf3no/cRADIlP3/dVm4eZ48sVwC/qYuRKnB843Qu1+rP4yzmZmTivApbetFkE+HN3ZQwcoMzj/smKw==",
             "dev": true,
             "requires": {
                 "minimatch": "^3.0.4"
@@ -18452,9 +18475,9 @@
             }
         },
         "@prettier/plugin-xml": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-0.13.0.tgz",
-            "integrity": "sha512-kjC8ZoqrNdSGyUfGS0KGxmA2YxI/mpO2bQtOsg8663DISyfvkN/1LoR8nO+0BaAKkGWhP2rzgk6rqiSEQz8vQw==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-0.13.1.tgz",
+            "integrity": "sha512-jJbjvFEsxOT2Jhv2yydOvJbnSREJy+OECwHyZaYr05jLXlJeBrzy5YY1fDYpwTfKk1B2YqNExXI+x3Zm5yGfeA==",
             "dev": true,
             "requires": {
                 "@xml-tools/parser": "^1.0.2",
@@ -18534,12 +18557,12 @@
             }
         },
         "@salesforce/eslint-config-lwc": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-0.9.0.tgz",
-            "integrity": "sha512-9O3UG5A9UW9Rga3OYadViO8bu8kMZLA0hjoUd14EkwVNfYypu6XkJH2QElaIPngSAmbVOdq5wh3hrtv2F5TQyw==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-0.11.0.tgz",
+            "integrity": "sha512-f1T92ZGXrURXRiMskci26ySb7o+gQR8Ycq6L+y2Q4U0GdeUAoHKnalvL/jQiXZ3eq6KLoKPv24gfeYfn6LJcgA==",
             "dev": true,
             "requires": {
-                "@lwc/eslint-plugin-lwc": "~0.11.0",
+                "@lwc/eslint-plugin-lwc": "~0.12.2",
                 "babel-eslint": "~10.1.0",
                 "eslint-plugin-import": "~2.22.1",
                 "eslint-plugin-jest": "~23.8.2",
@@ -21676,9 +21699,9 @@
             }
         },
         "eslint": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-            "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+            "version": "7.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+            "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
@@ -21698,7 +21721,7 @@
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^5.0.0",
-                "globals": "^12.1.0",
+                "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
@@ -21706,7 +21729,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -21779,12 +21802,12 @@
                     "dev": true
                 },
                 "globals": {
-                    "version": "12.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "version": "13.7.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+                    "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
                     "dev": true,
                     "requires": {
-                        "type-fest": "^0.8.1"
+                        "type-fest": "^0.20.2"
                     }
                 },
                 "has-flag": {
@@ -21840,6 +21863,12 @@
                     "requires": {
                         "prelude-ls": "^1.2.1"
                     }
+                },
+                "type-fest": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+                    "dev": true
                 }
             }
         },
@@ -22720,9 +22749,9 @@
             "dev": true
         },
         "husky": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.3.tgz",
-            "integrity": "sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-5.2.0.tgz",
+            "integrity": "sha512-AM8T/auHXRBxlrfPVLKP6jt49GCM2Zz47m8G3FOMsLmTv8Dj/fKVWE0Rh2d4Qrvmy131xEsdQnb3OXRib67PGg==",
             "dev": true
         },
         "iconv-lite": {
@@ -25344,9 +25373,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
     "scripts": {
         "lint": "npm run lint:lwc",
         "lint:lwc": "eslint **/lwc/**",
-        "test": "npm run lint && npm run test:unit",
-        "test:unit": "sfdx-lwc-jest",
-        "test:unit:watch": "sfdx-lwc-jest --watch",
-        "test:unit:debug": "sfdx-lwc-jest --debug",
-        "test:unit:coverage": "sfdx-lwc-jest --coverage",
+        "test": "npm run test:unit",
+        "test:unit": "sfdx-lwc-jest --skipApiVersionCheck",
+        "test:unit:watch": "sfdx-lwc-jest --watch --skipApiVersionCheck",
+        "test:unit:debug": "sfdx-lwc-jest --debug --skipApiVersionCheck",
+        "test:unit:coverage": "sfdx-lwc-jest --coverage --skipApiVersionCheck",
         "prettier": "prettier --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
         "prettier:verify": "prettier --list-different \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
         "postinstall": "node bin/check-version.js && husky install",
-        "precommit": "npm run prettier && npm run test"
+        "precommit": "npm run prettier:verify && [ $? -eq 0 ] && (npm run lint && npm run test) || exit -1"
     },
     "author": "salesforce.com",
     "license": "CC0-1.0",
@@ -27,13 +27,13 @@
         "npm": ">= 6.5.0"
     },
     "devDependencies": {
-        "@prettier/plugin-xml": "^0.13.0",
+        "@prettier/plugin-xml": "^0.13.1",
         "@sa11y/jest": "^0.3.0",
-        "@salesforce/eslint-config-lwc": "^0.9.0",
+        "@salesforce/eslint-config-lwc": "^0.11.0",
         "@salesforce/sfdx-lwc-jest": "^0.10.4",
-        "eslint": "^7.21.0",
+        "eslint": "^7.22.0",
         "eslint-config-prettier": "^8.1.0",
-        "husky": "^5.1.3",
+        "husky": "^5.2.0",
         "prettier": "^2.2.1",
         "prettier-plugin-apex": "^1.8.0",
         "semver": "^7.3.4"


### PR DESCRIPTION
- aligned CI workflows with other sample apps
- skip version checks on Jest
- got rid of GS0 DevHub (using `release=Preview` flag to create pre-release scratch orgs)