### PR TITLE
fix: import createElement from @lwc/engine-dom instead of lwc to remove error

### DIFF
--- a/force-app/main/default/lwc/accountMap/__tests__/accountMap.test.js
+++ b/force-app/main/default/lwc/accountMap/__tests__/accountMap.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import AccountMap from 'c/accountMap';
 import { getRecord } from 'lightning/uiRecordApi';
 

--- a/force-app/main/default/lwc/errorPanel/__tests__/errorPanel.test.js
+++ b/force-app/main/default/lwc/errorPanel/__tests__/errorPanel.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ErrorPanel from 'c/errorPanel';
 
 describe('c-error-panel', () => {

--- a/force-app/main/default/lwc/hero/__tests__/hero.test.js
+++ b/force-app/main/default/lwc/hero/__tests__/hero.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import Hero from 'c/hero';
 import IMAGE_URL from '@salesforce/resourceUrl/bike_assets';
 

--- a/force-app/main/default/lwc/heroDetails/__tests__/heroDetails.test.js
+++ b/force-app/main/default/lwc/heroDetails/__tests__/heroDetails.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import HeroDetails from 'c/heroDetails';
 import getRecordInfo from '@salesforce/apex/ProductRecordInfoController.getRecordInfo';
 

--- a/force-app/main/default/lwc/orderBuilder/__tests__/orderBuilder.test.js
+++ b/force-app/main/default/lwc/orderBuilder/__tests__/orderBuilder.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import OrderBuilder from 'c/orderBuilder';
 import getOrderItems from '@salesforce/apex/OrderController.getOrderItems';
 

--- a/force-app/main/default/lwc/orderStatusPath/__tests__/orderStatusPath.test.js
+++ b/force-app/main/default/lwc/orderStatusPath/__tests__/orderStatusPath.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import OrderStatusPath from 'c/orderStatusPath';
 import { getObjectInfo, getPicklistValues } from 'lightning/uiObjectInfoApi';
 import { getRecord, updateRecord } from 'lightning/uiRecordApi';

--- a/force-app/main/default/lwc/paginator/__tests__/paginator.test.js
+++ b/force-app/main/default/lwc/paginator/__tests__/paginator.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import Paginator from 'c/paginator';
 
 describe('c-paginator', () => {

--- a/force-app/main/default/lwc/placeholder/__tests__/placeholder.test.js
+++ b/force-app/main/default/lwc/placeholder/__tests__/placeholder.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import Placeholder from 'c/placeholder';
 
 describe('c-placeholder', () => {

--- a/force-app/main/default/lwc/productFilter/__tests__/productFilter.accessibility.test.js
+++ b/force-app/main/default/lwc/productFilter/__tests__/productFilter.accessibility.test.js
@@ -4,7 +4,7 @@
  * because of which fake timers leak into all the tests in the same file,
  * while Axe doen't work when using fake timers.
  **/
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ProductFilter from 'c/productFilter';
 import { getPicklistValues } from 'lightning/uiObjectInfoApi';
 

--- a/force-app/main/default/lwc/productFilter/__tests__/productFilter.test.js
+++ b/force-app/main/default/lwc/productFilter/__tests__/productFilter.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ProductFilter from 'c/productFilter';
 import { getPicklistValues } from 'lightning/uiObjectInfoApi';
 import { publish } from 'lightning/messageService';

--- a/force-app/main/default/lwc/productListItem/__tests__/productListItem.test.js
+++ b/force-app/main/default/lwc/productListItem/__tests__/productListItem.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ProductListItem from 'c/productListItem';
 import { getNavigateCalledWith } from 'lightning/navigation';
 

--- a/force-app/main/default/lwc/productTile/__tests__/productTile.test.js
+++ b/force-app/main/default/lwc/productTile/__tests__/productTile.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ProductTile from 'c/productTile';
 
 describe('c-product-tile', () => {

--- a/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
+++ b/force-app/main/default/lwc/productTileList/__tests__/productTileList.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import ProductTileList from 'c/productTileList';
 import { publish } from 'lightning/messageService';
 import PRODUCTS_FILTERED_MESSAGE from '@salesforce/messageChannel/ProductsFiltered__c';

--- a/force-app/main/default/lwc/similarProducts/__tests__/similarProducts.test.js
+++ b/force-app/main/default/lwc/similarProducts/__tests__/similarProducts.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import SimilarProducts from 'c/similarProducts';
 import { getRecord } from 'lightning/uiRecordApi';
 import getSimilarProducts from '@salesforce/apex/ProductController.getSimilarProducts';


### PR DESCRIPTION
### What does this PR do?
In all LWC test files, replaces `import { createElement } from 'lwc';` with `import { createElement } from '@lwc/engine-dom';`

### What issues does this PR fix or reference?
[skip-validate-pr]

## The PR fulfills these requirements:
✅ Tests for the proposed changes have been added/updated.
✅ Code linting and formatting was performed.

### Functionality Before
<img width="1840" alt="Screenshot 2025-06-02 at 2 03 59 PM" src="https://github.com/user-attachments/assets/f1296f7b-d895-47d1-8bd1-7d7ffacf8f06" />

### Functionality After
All errors are gone from the Problems Tab.