### PR TITLE
chore: ignore blocked major dependency updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
       schedule:
           interval: monthly
       open-pull-requests-limit: 10
+      ignore:
+          # Held: @salesforce/eslint-config-lwc / @lwc/eslint-plugin-lwc still pin eslint ^9.
+          # Re-enable when an eslint-10-compatible Salesforce config ships.
+          - dependency-name: 'eslint'
+            update-types: ['version-update:semver-major']
+          # Held: @babel/* v8 requires a coordinated migration (see remediation plan).
+          - dependency-name: '@babel/*'
+            update-types: ['version-update:semver-major']


### PR DESCRIPTION
Adds Dependabot `ignore` rules so blocked major-version bumps stop being re-proposed every cycle (they fail CI at `npm ci` on an ERESOLVE peer conflict and cannot be merged locally).

- **eslint 9 → 10:** held because `@salesforce/eslint-config-lwc` and `@lwc/eslint-plugin-lwc` still pin `eslint@^9`. Re-enable when an eslint-10-compatible Salesforce config ships.
- **@babel/* 7 → 8:** held pending a coordinated babel-8 migration (all `@babel/*` bumped together in one PR), rather than four independent Dependabot PRs.

This complements the recently-closed blocked Dependabot PRs — closing them treated the symptom; these rules stop them from coming back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)